### PR TITLE
only get inventory if it exists

### DIFF
--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -73,7 +73,13 @@ class SlurmdPeer(Object):
 
         slurmd_info = [
             json.loads(relation.data[peer]['inventory'])
-            for peer in peers if peer.name in slurmd_peers
+            for peer in peers if (
+                (peer.name in slurmd_peers) and (
+                    (relation.data.get(peer)) and (
+                        relation.data[peer].get('inventory')
+                    )
+                )
+            )
         ]
 
         # Add our own inventory to the slurmd_info


### PR DESCRIPTION
Check that inventory exists in the peer relation data before actually grabbing it.

Fixes https://github.com/omnivector-solutions/slurm-charms/issues/35