### PR TITLE
176641412 add remove nodes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+line-length = 88

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -184,7 +184,7 @@ jobs:
   release-slurm-charms-to-edge:
     name: "Push slurm charms to s3"
     runs-on: "ubuntu-latest"
-    needs: [deploy-slurm-focal-on-aws]
+    needs: [deploy-slurm-focal-beta-on-aws]
     steps:
       - name: "Configure AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -133,9 +133,9 @@ jobs:
         shell: bash
         run: |
           for charm in slurmctld slurmd slurmrestd slurm-configurator slurmdbd; do
-            juju deploy ./$charm.charm --series focal --bind nat --constraints "instance-type=t3.medium spaces=nat"
+            juju deploy -m ${{ steps.vars.outputs.sha_short }}-focal ./$charm.charm --series focal --bind nat --constraints "instance-type=t3.medium spaces=nat"
           done
-          juju deploy percona-cluster --bind nat --constraints "instance-type=t3.medium spaces=nat"
+          juju deploy -m ${{ steps.vars.outputs.sha_short }}-focal percona-cluster --bind nat --constraints "instance-type=t3.medium spaces=nat"
 
           juju relate slurmdbd percona-cluster
           juju relate slurmd slurm-configurator

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -133,9 +133,9 @@ jobs:
         shell: bash
         run: |
           for charm in slurmctld slurmd slurmrestd slurm-configurator slurmdbd; do
-            juju deploy ./$charm.charm --series focal --bind nat
+            juju deploy ./$charm.charm --series focal --bind nat --constraints "instance-type=t3.medium spaces=nat"
           done
-          juju deploy percona-cluster --bind nat
+          juju deploy percona-cluster --bind nat --constraints "instance-type=t3.medium spaces=nat"
 
           juju relate slurmdbd percona-cluster
           juju relate slurmd slurm-configurator

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -78,7 +78,7 @@ jobs:
     outputs:
       charm_hash: ${{ steps.vars.outputs.charm_hash }}
 
-  deploy-slurm-focal-on-aws:
+  deploy-slurm-focal-beta-on-aws:
     name: "Deploy focal on aws"
     runs-on: "ubuntu-latest"
     needs: [cache-juju-tar, build-charms]
@@ -128,27 +128,17 @@ jobs:
           juju add-space -m ${{ steps.vars.outputs.sha_short }}-focal nat 172.31.80.0/24 172.31.81.0/24 172.31.82.0/24 172.31.83.0/24
           juju model-config logging-config="<root>=DEBUG;<unit>=DEBUG"
 
-      - name: "Deploy charms"
+      - name: "Deploy charms using the snap from the beta channel"
         if: ${{ success() }}
         shell: bash
         run: |
-          for charm in slurmctld slurmd slurmrestd slurm-configurator slurmdbd; do
-            juju deploy -m ${{ steps.vars.outputs.sha_short }}-focal ./$charm.charm --series focal --bind nat --constraints "instance-type=t3.medium spaces=nat"
-          done
-          juju deploy -m ${{ steps.vars.outputs.sha_short }}-focal percona-cluster --bind nat --constraints "instance-type=t3.medium spaces=nat"
-
-          juju relate slurmdbd percona-cluster
-          juju relate slurmd slurm-configurator
-          juju relate slurmdbd slurm-configurator
-          juju relate slurmctld slurm-configurator
-          juju relate slurmrestd slurm-configurator
+          juju deploy -m ${{ steps.vars.outputs.sha_short }}-focal ./bundles/slurm-core/focal-beta-bundle.yaml
 
       - name: "Wait for deployment to settle"
         if: ${{ success() }}
         run: |
           sudo snap install juju-wait --classic
           juju-wait
-          sleep 5
 
       - name: "Test sinfo works"
         if: ${{ success() }}

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -31,6 +31,12 @@ jobs:
           pip install charmcraft
           make charms
 
+      - name: "Store charm hash filename for later use"
+        if: ${{ success() }}
+        id: vars
+        run: |
+          echo "::set-output name=charm_hash::${{hashFiles('*.charm')}}"
+
       - name: Cache built charms
         if: ${{ success() }}
         id: slurm-charms
@@ -42,7 +48,7 @@ jobs:
             slurmctld.charm
             slurmrestd.charm
             slurm-configurator.charm
-          key: slurm-charms
+          key: slurm-charms-${{ steps.vars.outputs.charm_hash }}
   
   cache-juju-tar:
     name: "Cache juju tar for future jobs"
@@ -69,6 +75,8 @@ jobs:
           path: |
             .local/share/juju
           key: juju-tar
+    outputs:
+      charm_hash: ${{ steps.vars.outputs.charm_hash }}
 
   deploy-slurm-focal-on-aws:
     name: "Deploy focal on aws"
@@ -98,7 +106,8 @@ jobs:
             slurmctld.charm
             slurmrestd.charm
             slurm-configurator.charm
-          key: slurm-charms
+          key: slurm-charms-${{ needs.build-charms.outputs.charm_hash }}
+
 
       - name: "Set JUJU_DATA to GITHUB_ENV"
         run: |

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -148,11 +148,12 @@ jobs:
         run: |
           sudo snap install juju-wait --classic
           juju-wait
+          sleep 5
 
       - name: "Test sinfo works"
         if: ${{ success() }}
         run: |
-          juju run "sinfo" --unit slurmd/0
+          juju run "sinfo" --unit slurm-configurator/0
 
       - name: "Remove applications from juju model"
         if: ${{ always() }}

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -125,7 +125,7 @@ jobs:
         if: ${{ success() }}
         run: |
           juju add-model ${{ steps.vars.outputs.sha_short }}-focal
-          juju add-space -m ${{ steps.vars.outputs.sha_short }}-focal nat 172.31.90.0/24 172.31.91.0/24 172.31.92.0/24 172.31.93.0/24
+          juju add-space -m ${{ steps.vars.outputs.sha_short }}-focal nat 172.31.80.0/24 172.31.81.0/24 172.31.82.0/24 172.31.83.0/24
           juju model-config logging-config="<root>=DEBUG;<unit>=DEBUG"
 
       - name: "Deploy charms"

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,22 @@ clean: ## Remove .tox and build dirs
 	rm -rf venv/
 	rm -rf *.charm
 
-charms: ## Build all charms
+slurmd: ## Build slurmd
 	@charmcraft build --from charm-slurmd
+
+slurmctld: ## Build slurmctld
 	@charmcraft build --from charm-slurmctld
+
+slurmdbd: ## Build slurmdbd
 	@charmcraft build --from charm-slurmdbd
-	@charmcraft build --from charm-slurmrestd
+
+slurm-configurator: ## Build slurm-configurator
 	@charmcraft build --from charm-slurm-configurator
+
+slurmrestd: ## Build slurmrestd
+	@charmcraft build --from charm-slurmrestd
+
+charms: slurmd slurmdbd slurmctld slurmrestd slurm-configurator ## Build all charms
 
 pull-classic-snap: ## Pull the classic slurm snap from github
 	@wget https://github.com/omnivector-solutions/snap-slurm/releases/download/20.02/slurm_20.02.1_amd64_classic.snap -O slurm.resource

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ push-charms-to-edge: ## Push charms to edge s3
 pull-charms-from-edge: clean ## pull charms from edge s3
 	@./scripts/pull_charms.sh edge
 
+format: # reformat source python files
+	isort charm-slurmd charm-slurmdbd charm-slurmctld charm-slurm-configurator --skip-glob '*/[0-9][0-9][0-9][0-9]*.py'
+	black charm-slurmd charm-slurmdbd charm-slurmctld charm-slurm-configurator --exclude '\d{4}.*\.py'
+
 # Display target comments in 'make help'
 help: 
 	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/bundles/slurm-core/bundle.yaml
+++ b/bundles/slurm-core/bundle.yaml
@@ -32,10 +32,10 @@ applications:
       slurmdbd: nat
       slurmrestd: nat
     resources:
-        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
-      custom_config: |
-        SlurmctldDebug=debug5
-        SlurmdDebug=debug5
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+    custom_config: |
+      SlurmctldDebug=debug5
+      SlurmdDebug=debug5
   slurmctld:
     charm: ./../../slurmctld.charm
     num_units: 1
@@ -46,7 +46,7 @@ applications:
       slurmctld: nat
       slurmctld-peer: nat
     resources:
-        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
   slurmd:
     charm: ./../../slurmd.charm
     num_units: 1
@@ -57,7 +57,7 @@ applications:
       slurmd: nat
       slurmd-peer: nat
     resources:
-        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
   slurmdbd:
     charm: ./../../slurmdbd.charm
     num_units: 1
@@ -69,7 +69,7 @@ applications:
       slurmdbd: nat
       slurmdbd-peer: nat
     resources:
-        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
 relations:
   - - slurmdbd:db
     - percona-cluster:db

--- a/bundles/slurm-core/bundle.yaml
+++ b/bundles/slurm-core/bundle.yaml
@@ -1,0 +1,78 @@
+series: focal
+applications:
+  percona-cluster:
+    charm: cs:percona-cluster-293
+    series: bionic
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      access: nat
+      cluster: nat
+      db: nat
+      db-admin: nat
+      ha: nat
+      master: nat
+      nrpe-external-master: nat
+      shared-db: nat
+      slave: nat
+  slurm-configurator:
+    charm: ./../../slurm-configurator.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      elasticsearch: nat
+      grafana-source: nat
+      influxdb-api: nat
+      nhc: nat
+      prolog-epilog: nat
+      slurmctld: nat
+      slurmd: nat
+      slurmdbd: nat
+      slurmrestd: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmctld:
+    charm: ./../../slurmctld.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmctld: nat
+      slurmctld-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmd:
+    charm: ./../../slurmd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmd: nat
+      slurmd-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmdbd:
+    charm: ./../../slurmdbd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      db: nat
+      nrpe-external-master: nat
+      slurmdbd: nat
+      slurmdbd-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+relations:
+  - - slurmdbd:db
+    - percona-cluster:db
+  - - slurm-configurator:slurmdbd
+    - slurmdbd:slurmdbd
+  - - slurm-configurator:slurmd
+    - slurmd:slurmd
+  - - slurm-configurator:slurmctld
+    - slurmctld:slurmctld

--- a/bundles/slurm-core/bundle.yaml
+++ b/bundles/slurm-core/bundle.yaml
@@ -33,6 +33,9 @@ applications:
       slurmrestd: nat
     resources:
         slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+      custom_config: |
+        SlurmctldDebug=debug5
+        SlurmdDebug=debug5
   slurmctld:
     charm: ./../../slurmctld.charm
     num_units: 1

--- a/bundles/slurm-core/focal-beta-bundle.yaml
+++ b/bundles/slurm-core/focal-beta-bundle.yaml
@@ -16,6 +16,15 @@ applications:
       nrpe-external-master: nat
       shared-db: nat
       slave: nat
+  slurmrestd:
+    charm: ./../../slurmrestd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      slurmrestd: nat
+    options:
+      snapstore-channel: "--beta"
   slurm-configurator:
     charm: ./../../slurm-configurator.charm
     num_units: 1

--- a/bundles/slurm-core/focal-beta-bundle.yaml
+++ b/bundles/slurm-core/focal-beta-bundle.yaml
@@ -31,11 +31,11 @@ applications:
       slurmd: nat
       slurmdbd: nat
       slurmrestd: nat
-    resources:
-      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
-    custom_config: |
-      SlurmctldDebug=debug5
-      SlurmdDebug=debug5
+    options:
+      custom_config: |
+        SlurmctldDebug=debug5
+        SlurmdDebug=debug5
+      snapstore-channel: "--beta"
   slurmctld:
     charm: ./../../slurmctld.charm
     num_units: 1
@@ -45,8 +45,8 @@ applications:
       nrpe-external-master: nat
       slurmctld: nat
       slurmctld-peer: nat
-    resources:
-      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+    options:
+      snapstore-channel: "--beta"
   slurmd:
     charm: ./../../slurmd.charm
     num_units: 1
@@ -56,8 +56,8 @@ applications:
       nrpe-external-master: nat
       slurmd: nat
       slurmd-peer: nat
-    resources:
-      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+    options:
+      snapstore-channel: "--beta"
   slurmdbd:
     charm: ./../../slurmdbd.charm
     num_units: 1
@@ -68,8 +68,8 @@ applications:
       nrpe-external-master: nat
       slurmdbd: nat
       slurmdbd-peer: nat
-    resources:
-      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+    options:
+      snapstore-channel: "--beta"
 relations:
   - - slurmdbd:db
     - percona-cluster:db

--- a/bundles/slurm-core/focal-local.yaml
+++ b/bundles/slurm-core/focal-local.yaml
@@ -1,0 +1,78 @@
+series: focal
+applications:
+  percona-cluster:
+    charm: cs:percona-cluster-293
+    series: bionic
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      access: nat
+      cluster: nat
+      db: nat
+      db-admin: nat
+      ha: nat
+      master: nat
+      nrpe-external-master: nat
+      shared-db: nat
+      slave: nat
+  slurm-configurator:
+    charm: ./../../slurm-configurator.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      elasticsearch: nat
+      grafana-source: nat
+      influxdb-api: nat
+      nhc: nat
+      prolog-epilog: nat
+      slurmctld: nat
+      slurmd: nat
+      slurmdbd: nat
+      slurmrestd: nat
+    resources:
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmctld:
+    charm: ./../../slurmctld.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmctld: nat
+      slurmctld-peer: nat
+    resources:
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmd:
+    charm: ./../../slurmd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmd: nat
+      slurmd-peer: nat
+    resources:
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+  slurmdbd:
+    charm: ./../../slurmdbd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      db: nat
+      nrpe-external-master: nat
+      slurmdbd: nat
+      slurmdbd-peer: nat
+    resources:
+      slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+relations:
+  - - slurmdbd:db
+    - percona-cluster:db
+  - - slurm-configurator:slurmdbd
+    - slurmdbd:slurmdbd
+  - - slurm-configurator:slurmd
+    - slurmd:slurmd
+  - - slurm-configurator:slurmctld
+    - slurmctld:slurmctld

--- a/bundles/slurm-core/slurm-configurator.yaml
+++ b/bundles/slurm-core/slurm-configurator.yaml
@@ -1,0 +1,23 @@
+series: focal
+applications:
+  slurm-configurator:
+    charm: ./../../slurm-configurator.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      elasticsearch: nat
+      grafana-source: nat
+      influxdb-api: nat
+      nhc: nat
+      prolog-epilog: nat
+      slurmctld: nat
+      slurmd: nat
+      slurmdbd: nat
+      slurmrestd: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+    options:
+      custom_config: |
+        SlurmctldDebug=debug5
+        SlurmdDebug=debug5

--- a/bundles/slurm-core/slurmctld.yaml
+++ b/bundles/slurm-core/slurmctld.yaml
@@ -1,0 +1,13 @@
+series: focal
+applications:
+  slurmctld:
+    charm: ./../../slurmctld.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmctld: nat
+      slurmctld-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource

--- a/bundles/slurm-core/slurmd.yaml
+++ b/bundles/slurm-core/slurmd.yaml
@@ -1,0 +1,13 @@
+series: focal
+applications:
+  slurmd:
+    charm: ./../../slurmd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      nrpe-external-master: nat
+      slurmd: nat
+      slurmd-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource

--- a/bundles/slurm-core/slurmdbd.yaml
+++ b/bundles/slurm-core/slurmdbd.yaml
@@ -1,0 +1,33 @@
+series: focal
+applications:
+  percona-cluster:
+    charm: cs:percona-cluster-293
+    series: bionic
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      access: nat
+      cluster: nat
+      db: nat
+      db-admin: nat
+      ha: nat
+      master: nat
+      nrpe-external-master: nat
+      shared-db: nat
+      slave: nat
+  slurmdbd:
+    charm: ./../../slurmdbd.charm
+    num_units: 1
+    constraints: instance-type=t3.medium spaces=nat
+    bindings:
+      "": nat
+      db: nat
+      nrpe-external-master: nat
+      slurmdbd: nat
+      slurmdbd-peer: nat
+    resources:
+        slurm: ./../../../snap-slurm/slurm_20.11.3_amd64.resource
+relations:
+  - - slurmdbd:db
+    - percona-cluster:db

--- a/charm-slurm-configurator/actions.yaml
+++ b/charm-slurm-configurator/actions.yaml
@@ -1,0 +1,19 @@
+restart-slurmctld:
+  description: Restart the slurmctld process.
+
+restart-slurmd:
+  description: Restart the slurmd process.
+
+get-slurm-conf:
+  description: Return the slurm.conf file as a string.
+
+set-slurm-conf:
+  description: Set a slurm.conf string that will override any configuration created by juju.
+  params:
+    slurm-conf:
+      type: string
+      description: The slurm.conf as a string.
+  required: [slurm-conf]
+
+scontrol-reconfigure:
+  description: Run the scontrol reconfigur command.

--- a/charm-slurm-configurator/config.yaml
+++ b/charm-slurm-configurator/config.yaml
@@ -1,45 +1,59 @@
 options:
+  configless:
+    type: boolean
+    default: false
+    description: |
+      "Configless" Slurm is a feature that allows the compute 
+      nodes — specifically the slurmd process — and user commands
+      running on login nodes to pull configuration information directly
+      from the slurmctld instead of from a pre-distributed local file.
+
+      Setting this to true (default) will add
+
+          SlurmctldParameters=enable_configless
+
+      to the slurm.conf
   cluster_name:
     type: string
     default: cluster1
-    description: >-
-      'Name to be recorded in database for jobs from this cluster.  This is
-      important if a single database is used to record information  from
-      multiple Slurm-managed clusters.'
+    description: |
+      Name to be recorded in database for jobs from this cluster.  This is
+      important if a single database is used to record information from
+      multiple Slurm-managed clusters.
   default_partition:
     type: string
     default: ""
-    description: >-
-      'Default partition. This is only used if defined, and must match an existing partition.'
+    description: |
+      Default partition. This is only used if defined, and must match an existing partition.
   acct_gather_custom:
     type: string
     default: ""
-    description: >-
-      'User supplied acct_gather.conf confinguration.'
+    description: |
+      User supplied acct_gather.conf confinguration.
   custom_config:
     type: string
     default: ""
-    description: >-
-      'User supplied slurm confinguration'
+    description: |
+      User supplied slurm confinguration
   proctrack_type:
     type: string
     default: proctrack/cgroup
-    description: >-
-      'Identifies the plugin to be used for process tracking on a job step basis.'
+    description: |
+      Identifies the plugin to be used for process tracking on a job step basis.
   cgroup_config:
     type: string
     default: |
       CgroupAutomount=yes
       ConstrainCores=yes
-    description: >-
-      'Configuration content for cgroup.conf'
+    description: |
+      Configuration content for cgroup.conf
   node_weight_criteria:
     type: string
     default: none
-    description: >-
-      'What type of node criteria to use for setting weights on nodes.
+    description: |
+      What type of node criteria to use for setting weights on nodes.
       By default all nodes have Weight=1. When it is preferable to
       allocate for example smaller memory nodes for smaller jobs, low
       weights should be assigned to smaller nodes. Setting this charm
       option will automatically order and weigh the nodes in ascending
-      order. Allowed values are RealMemory, CPUs and CoresPerSocket.'
+      order. Allowed values are RealMemory, CPUs and CoresPerSocket.

--- a/charm-slurm-configurator/config.yaml
+++ b/charm-slurm-configurator/config.yaml
@@ -1,18 +1,9 @@
 options:
-  configless:
-    type: boolean
-    default: false
-    description: |
-      "Configless" Slurm is a feature that allows the compute 
-      nodes — specifically the slurmd process — and user commands
-      running on login nodes to pull configuration information directly
-      from the slurmctld instead of from a pre-distributed local file.
-
-      Setting this to true (default) will add
-
-          SlurmctldParameters=enable_configless
-
-      to the slurm.conf
+  snapstore-channel:
+    type: string
+    default: "--stable"
+    description:
+      'Snap store channel to install the slurm snap from.'
   cluster_name:
     type: string
     default: cluster1

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v15

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -9,19 +9,15 @@ from interface_influxdb import InfluxDB
 from interface_nhc import Nhc
 from interface_prolog_epilog import PrologEpilog
 from interface_slurmctld import Slurmctld
-from interface_slurmd import Slurmd
 from interface_slurmdbd import Slurmdbd
 from interface_slurmrestd import Slurmrestd
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-    WaitingStatus,
-)
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 
+from interface_slurmd import Slurmd
 
 logger = logging.getLogger()
 
@@ -42,7 +38,6 @@ class SlurmConfiguratorCharm(CharmBase):
             slurmdbd_available=False,
             slurmd_available=False,
             slurmrestd_available=False,
-
         )
 
         self._elasticsearch = Elasticsearch(self, "elasticsearch")
@@ -60,64 +55,28 @@ class SlurmConfiguratorCharm(CharmBase):
         event_handler_bindings = {
             # #### Juju lifecycle events #### #
             self.on.install: self._on_install,
-
             # self.on.start:
             # self._on_check_status_and_write_config,
-
-            self.on.config_changed:
-            self._on_check_status_and_write_config,
-
+            self.on.config_changed: self._on_check_status_and_write_config,
             self.on.upgrade_charm: self._on_upgrade,
-
             # ######## Addons lifecycle events ######## #
-            self._elasticsearch.on.elasticsearch_available:
-            self._on_check_status_and_write_config,
-
-            self._elasticsearch.on.elasticsearch_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._grafana.on.grafana_available:
-            self._on_grafana_available,
-
-            self._influxdb.on.influxdb_available:
-            self._on_influxdb_available,
-
-            self._influxdb.on.influxdb_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._nhc.on.nhc_bin_available:
-            self._on_check_status_and_write_config,
-
+            self._elasticsearch.on.elasticsearch_available: self._on_check_status_and_write_config,
+            self._elasticsearch.on.elasticsearch_unavailable: self._on_check_status_and_write_config,
+            self._grafana.on.grafana_available: self._on_grafana_available,
+            self._influxdb.on.influxdb_available: self._on_influxdb_available,
+            self._influxdb.on.influxdb_unavailable: self._on_check_status_and_write_config,
+            self._nhc.on.nhc_bin_available: self._on_check_status_and_write_config,
             # ######## Slurm component lifecycle events ######## #
-            self._slurmctld.on.slurmctld_available:
-            self._on_check_status_and_write_config,
-
-            self._slurmctld.on.slurmctld_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._slurmdbd.on.slurmdbd_available:
-            self._on_check_status_and_write_config,
-
-            self._slurmdbd.on.slurmdbd_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._slurmd.on.slurmd_available:
-            self._on_check_status_and_write_config,
-
-            self._slurmd.on.slurmd_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._slurmrestd.on.slurmrestd_available:
-            self._on_check_status_and_write_config,
-
-            self._slurmrestd.on.slurmrestd_unavailable:
-            self._on_check_status_and_write_config,
-
-            self._prolog_epilog.on.prolog_epilog_available:
-            self._on_check_status_and_write_config,
-
-            self._prolog_epilog.on.prolog_epilog_unavailable:
-            self._on_check_status_and_write_config,
+            self._slurmctld.on.slurmctld_available: self._on_check_status_and_write_config,
+            self._slurmctld.on.slurmctld_unavailable: self._on_check_status_and_write_config,
+            self._slurmdbd.on.slurmdbd_available: self._on_check_status_and_write_config,
+            self._slurmdbd.on.slurmdbd_unavailable: self._on_check_status_and_write_config,
+            self._slurmd.on.slurmd_available: self._on_check_status_and_write_config,
+            self._slurmd.on.slurmd_unavailable: self._on_check_status_and_write_config,
+            self._slurmrestd.on.slurmrestd_available: self._on_check_status_and_write_config,
+            self._slurmrestd.on.slurmrestd_unavailable: self._on_check_status_and_write_config,
+            self._prolog_epilog.on.prolog_epilog_available: self._on_check_status_and_write_config,
+            self._prolog_epilog.on.prolog_epilog_unavailable: self._on_check_status_and_write_config,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -189,7 +148,7 @@ class SlurmConfiguratorCharm(CharmBase):
                 slurm_config,
             )
         self._slurm_manager.render_config_and_restart(
-            {**slurm_config, 'munge_key': self.get_munge_key()}
+            {**slurm_config, "munge_key": self.get_munge_key()}
         )
 
     def _assemble_slurm_config(self):
@@ -210,8 +169,8 @@ class SlurmConfiguratorCharm(CharmBase):
         logger.debug(slurmdbd_info)
 
         return {
-            'munge_key': self._stored.munge_key,
-            'partitions': partitions_info,
+            "munge_key": self._stored.munge_key,
+            "partitions": partitions_info,
             **slurmctld_info,
             **slurmdbd_info,
             **addons_info,
@@ -229,10 +188,8 @@ class SlurmConfiguratorCharm(CharmBase):
             partition_tmp = copy.deepcopy(partition)
             # Extract the partition_name from the partition and from the charm
             # config.
-            partition_name = partition['partition_name']
-            default_partition_from_config = self.model.config.get(
-                'default_partition'
-            )
+            partition_name = partition["partition_name"]
+            default_partition_from_config = self.model.config.get("default_partition")
 
             # Check that the default_partition isn't defined in the charm
             # config.
@@ -240,11 +197,11 @@ class SlurmConfiguratorCharm(CharmBase):
             # the partition_default by defaulting to the first related slurmd
             # application.
             if not default_partition_from_config:
-                if partition['partition_name'] == "configurator":
-                    partition_tmp['partition_default'] = 'YES'
+                if partition["partition_name"] == "configurator":
+                    partition_tmp["partition_default"] = "YES"
             else:
                 if default_partition_from_config == partition_name:
-                    partition_tmp['partition_default'] = 'YES'
+                    partition_tmp["partition_default"] = "YES"
 
             slurmd_info_tmp.remove(partition)
             slurmd_info_tmp.append(partition_tmp)
@@ -254,31 +211,30 @@ class SlurmConfiguratorCharm(CharmBase):
     def _assemble_addons(self):
         """Assemble any addon components."""
         acct_gather = self._get_influxdb_info()
-        elasticsearch_ingress = \
-            self._elasticsearch.get_elasticsearch_ingress()
+        elasticsearch_ingress = self._elasticsearch.get_elasticsearch_ingress()
         nhc_info = self._nhc.get_nhc_info()
         prolog_epilog = self._prolog_epilog.get_prolog_epilog()
 
         ctxt = dict()
 
         if prolog_epilog:
-            ctxt['prolog_epilog'] = prolog_epilog
+            ctxt["prolog_epilog"] = prolog_epilog
 
         if acct_gather:
-            ctxt['acct_gather'] = acct_gather
-            acct_gather_custom = self.model.config.get('acct_gather_custom')
+            ctxt["acct_gather"] = acct_gather
+            acct_gather_custom = self.model.config.get("acct_gather_custom")
             if acct_gather_custom:
-                ctxt['acct_gather']['custom'] = acct_gather_custom
+                ctxt["acct_gather"]["custom"] = acct_gather_custom
 
         if nhc_info:
-            ctxt['nhc'] = {
-                'nhc_bin': nhc_info['nhc_bin'],
-                'health_check_interval': nhc_info['health_check_interval'],
-                'health_check_node_state': nhc_info['health_check_node_state'],
+            ctxt["nhc"] = {
+                "nhc_bin": nhc_info["nhc_bin"],
+                "health_check_interval": nhc_info["health_check_interval"],
+                "health_check_node_state": nhc_info["health_check_node_state"],
             }
 
         if elasticsearch_ingress:
-            ctxt['elasticsearch_address'] = elasticsearch_ingress
+            ctxt["elasticsearch_address"] = elasticsearch_ingress
 
         return ctxt
 

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -147,9 +147,7 @@ class SlurmConfiguratorCharm(CharmBase):
             self._slurmrestd.set_slurm_config_on_app_relation_data(
                 slurm_config,
             )
-        self._slurm_manager.render_config_and_restart(
-            {**slurm_config, "munge_key": self.get_munge_key()}
-        )
+        self._slurm_manager.render_config_and_restart(slurm_config)
 
     def _assemble_slurm_config(self):
         """Assemble and return the slurm config."""
@@ -169,7 +167,6 @@ class SlurmConfiguratorCharm(CharmBase):
         logger.debug(slurmdbd_info)
 
         return {
-            "munge_key": self._stored.munge_key,
             "partitions": partitions_info,
             **slurmctld_info,
             **slurmdbd_info,

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -284,40 +284,31 @@ class SlurmConfiguratorCharm(CharmBase):
 
     def _check_status(self):
         """Check that the core components we need exist."""
-        slurmctld_available = self._stored.slurmctld_available
-        slurmdbd_available = self._stored.slurmdbd_available
-        slurmd_available = self._stored.slurmd_available
-        slurm_installed = self._stored.slurm_installed
-
-        slurmctld_joined = self._slurmctld.is_joined
-        slurmdbd_joined = self._slurmdbd.is_joined
-        slurmd_joined = self._slurmd.is_joined
+        slurm_component_statuses = {
+            "slurmctld": {
+                "available": self._stored.slurmctld_available,
+                "joined": self._slurmctld.is_joined,
+            },
+            "slurmd": {
+                "available": self._stored.slurmd_available,
+                "joined": self._slurmd.is_joined,
+            },
+            "slurmdbd": {
+                "available": self._stored.slurmdbd_available,
+                "joined": self._slurmdbd.is_joined,
+            },
+        }
 
         relations_needed = []
         waiting_on = []
 
         msg = str()
 
-        if not slurmctld_available:
-            if not slurmctld_joined:
-                relations_needed.append("slurmctld")
+        for slurm_component in slurm_component_statuses.keys():
+            if not slurm_component_statuses[slurm_component]["joined"]:
+                relations_needed.append(slurm_component)
             else:
-                waiting_on.append("slurmctld")
-
-        if not slurmdbd_available:
-            if not slurmdbd_joined:
-                relations_needed.append("slurmdbd")
-            else:
-                waiting_on.append("slurmdbd")
-
-        if not slurmd_available:
-            if not slurmd_joined:
-                relations_needed.append("slurmd")
-            else:
-                waiting_on.append("slurmd")
-
-        if not slurm_installed:
-            waiting_on.append("snap install")
+                waiting_on.append(slurm_component)
 
         relations_needed_len = len(relations_needed)
         waiting_on_len = len(waiting_on)

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -326,7 +326,7 @@ class SlurmConfiguratorCharm(CharmBase):
         elif waiting_on_len > 0:
             self.unit.status = WaitingStatus(msg)
         else:
-            self.unit.status = ActiveStatus("")
+            self.unit.status = ActiveStatus("slurm-configurator available")
             return True
         return False
 

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -57,8 +57,6 @@ class SlurmConfiguratorCharm(CharmBase):
         event_handler_bindings = {
             # #### Juju lifecycle events #### #
             self.on.install: self._on_install,
-            # self.on.start:
-            # self._on_check_status_and_write_config,
             self.on.config_changed: self._on_check_status_and_write_config,
             self.on.upgrade_charm: self._on_upgrade,
             # ######## Addons lifecycle events ######## #
@@ -75,7 +73,6 @@ class SlurmConfiguratorCharm(CharmBase):
             self._slurmdbd.on.slurmdbd_unavailable: self._on_check_status_and_write_config,
             self._slurmd.on.slurmd_available: self._on_check_status_and_write_config,
             self._slurmd.on.slurmd_unavailable: self._on_check_status_and_write_config,
-            #self._slurmd.on.slurmd_departed: self._on_check_status_and_write_config,
             self._slurmrestd.on.slurmrestd_available: self._on_check_status_and_write_config,
             self._slurmrestd.on.slurmrestd_unavailable: self._on_check_status_and_write_config,
             self._prolog_epilog.on.prolog_epilog_available: self._on_check_status_and_write_config,
@@ -104,7 +101,6 @@ class SlurmConfiguratorCharm(CharmBase):
 
     def _on_get_slurm_conf(self, event):
         """Return the slurm.conf."""
-
         # Determine if we have an override config.
         override_slurm_conf = self._stored.override_slurm_conf
         if override_slurm_conf:

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -35,7 +35,6 @@ class SlurmConfiguratorCharm(CharmBase):
         super().__init__(*args)
 
         self._stored.set_default(
-            default_partition=str(),
             munge_key=str(),
             slurm_installed=False,
             slurmctld_available=False,
@@ -240,8 +239,7 @@ class SlurmConfiguratorCharm(CharmBase):
             # the partition_default by defaulting to the first related slurmd
             # application.
             if not default_partition_from_config:
-                if partition['partition_name'] ==\
-                   self._stored.default_partition:
+                if partition['partition_name'] == "configurator":
                     partition_tmp['partition_default'] = 'YES'
             else:
                 if default_partition_from_config == partition_name:
@@ -289,10 +287,8 @@ class SlurmConfiguratorCharm(CharmBase):
         slurmdbd_available = self._stored.slurmdbd_available
         slurmd_available = self._stored.slurmd_available
         slurm_installed = self._stored.slurm_installed
-        default_partition = self._stored.default_partition
 
         deps = [
-            default_partition,
             slurmctld_available,
             slurmdbd_available,
             slurmd_available,
@@ -306,10 +302,8 @@ class SlurmConfiguratorCharm(CharmBase):
                 self.unit.status = BlockedStatus("NEED RELATION TO SLURMDBD")
             elif not slurmd_available:
                 self.unit.status = BlockedStatus("NEED RELATION TO SLURMD")
-            elif not slurm_installed:
-                self.unit.status = BlockedStatus("SLURM NOT INSTALLED")
             else:
-                self.unit.status = BlockedStatus("PARTITION NAME UNAVAILABLE")
+                self.unit.status = BlockedStatus("SLURM NOT INSTALLED")
             return False
         else:
             self.unit.status = ActiveStatus("")
@@ -326,10 +320,6 @@ class SlurmConfiguratorCharm(CharmBase):
         """Return the slurmdbd_info from stored state."""
         return self._stored.munge_key
 
-    def get_default_partition(self):
-        """Return self._stored.default_partition."""
-        return self._stored.default_partition
-
     def is_slurm_installed(self):
         """Return true/false based on whether or not slurm is installed."""
         return self._stored.slurm_installed
@@ -341,10 +331,6 @@ class SlurmConfiguratorCharm(CharmBase):
     def set_slurmdbd_available(self, slurmdbd_available):
         """Set slurmdbd_available."""
         self._stored.slurmdbd_available = slurmdbd_available
-
-    def set_default_partition(self, partition_name):
-        """Set self._stored.default_partition."""
-        self._stored.default_partition = partition_name
 
     def set_slurmd_available(self, slurmd_available):
         """Set slurmd_available."""

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -117,7 +117,7 @@ class SlurmConfiguratorCharm(CharmBase):
 
     def _on_install(self, event):
         """Install the slurm snap and capture the munge key."""
-        self._slurm_manager.install()
+        self._slurm_manager.install(self.config["snapstore-channel"])
         self._stored.munge_key = self._slurm_manager.get_munge_key()
         self._stored.slurm_installed = True
         self.unit.status = ActiveStatus("slurm installed")

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -307,7 +307,7 @@ class SlurmConfiguratorCharm(CharmBase):
         for slurm_component in slurm_component_statuses.keys():
             if not slurm_component_statuses[slurm_component]["joined"]:
                 relations_needed.append(slurm_component)
-            else:
+            elif not slurm_component_statuses[slurm_component]["available"]:
                 waiting_on.append(slurm_component)
 
         relations_needed_len = len(relations_needed)

--- a/charm-slurm-configurator/src/interface_elasticsearch.py
+++ b/charm-slurm-configurator/src/interface_elasticsearch.py
@@ -2,13 +2,7 @@
 """Elasticserch interface."""
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 logger = logging.getLogger()
 
@@ -46,18 +40,18 @@ class Elasticsearch(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_changed(self, event):
         """Set elasticsearch_ingress to _stored."""
-        ingress = event.relation.data[event.unit]['ingress-address']
-        self._stored.elasticsearch_ingress = f'http://{ingress}:9200'
+        ingress = event.relation.data[event.unit]["ingress-address"]
+        self._stored.elasticsearch_ingress = f"http://{ingress}:9200"
         self.on.elasticsearch_available.emit()
 
     def _on_relation_broken(self, event):

--- a/charm-slurm-configurator/src/interface_grafana_source.py
+++ b/charm-slurm-configurator/src/interface_grafana_source.py
@@ -2,14 +2,7 @@
 """Grafana Source Interface."""
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 logger = logging.getLogger()
 
@@ -40,12 +33,12 @@ class GrafanaSource(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_joined,
-            self._on_relation_joined
+            self._on_relation_joined,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_joined(self, event):
@@ -55,10 +48,10 @@ class GrafanaSource(Object):
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():
             app_relation_data = self._relation.data[self.model.app]
-            app_relation_data['url'] = ""
-            app_relation_data['username'] = ""
-            app_relation_data['password'] = ""
-            app_relation_data['database'] = ""
+            app_relation_data["url"] = ""
+            app_relation_data["username"] = ""
+            app_relation_data["password"] = ""
+            app_relation_data["database"] = ""
             self._stored.grafana_source_created = False
 
     @property
@@ -74,10 +67,9 @@ class GrafanaSource(Object):
         """Set grafana source info on relation."""
         if self.framework.model.unit.is_leader():
             app_relation_data = self._relation.data[self.model.app]
-            app_relation_data['type'] = 'influxdb'
-            app_relation_data['url'] = \
-                f"{influxdb['ingress']}:{influxdb['port']}"
-            app_relation_data['username'] = influxdb['user']
-            app_relation_data['password'] = influxdb['password']
-            app_relation_data['database'] = influxdb['database']
+            app_relation_data["type"] = "influxdb"
+            app_relation_data["url"] = f"{influxdb['ingress']}:{influxdb['port']}"
+            app_relation_data["username"] = influxdb["user"]
+            app_relation_data["password"] = influxdb["password"]
+            app_relation_data["database"] = influxdb["database"]
             self._stored.grafana_source_created = True

--- a/charm-slurm-configurator/src/interface_influxdb.py
+++ b/charm-slurm-configurator/src/interface_influxdb.py
@@ -5,13 +5,7 @@ import logging
 import random
 
 import influxdb
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 logger = logging.getLogger()
 
@@ -37,9 +31,8 @@ def random_string(length=10):
     for i in range(length):
         random_integer = random.randint(97, 97 + 26 - 1)
         flip_bit = random.randint(0, 1)
-        random_integer = \
-            random_integer - 32 if flip_bit == 1 else random_integer
-        random_str += (chr(random_integer))
+        random_integer = random_integer - 32 if flip_bit == 1 else random_integer
+        random_str += chr(random_integer)
     return random_str
 
 
@@ -49,9 +42,9 @@ class InfluxDB(Object):
     _stored = StoredState()
     on = InfluxDBEvents()
 
-    _INFLUX_USER = 'slurm'
-    _INFLUX_DATABASE = 'slurm'
-    _INFLUX_PRIVILEGE = 'all'
+    _INFLUX_USER = "slurm"
+    _INFLUX_DATABASE = "slurm"
+    _INFLUX_PRIVILEGE = "all"
 
     def __init__(self, charm, relation_name):
         """Observe relation events."""
@@ -66,30 +59,32 @@ class InfluxDB(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_changed(self, event):
         """Store influxdb_ingress in the charm."""
         if self.framework.model.unit.is_leader():
             if not self._stored.influxdb_admin_info:
-                ingress = event.relation.data[event.unit]['ingress-address']
-                port = event.relation.data[event.unit].get('port')
-                user = event.relation.data[event.unit].get('user')
-                password = event.relation.data[event.unit].get('password')
+                ingress = event.relation.data[event.unit]["ingress-address"]
+                port = event.relation.data[event.unit].get("port")
+                user = event.relation.data[event.unit].get("user")
+                password = event.relation.data[event.unit].get("password")
 
                 if all([ingress, port, user, password]):
-                    self._stored.influxdb_admin_info = json.dumps({
-                        'ingress': ingress,
-                        'port': port,
-                        'user': user,
-                        'password': password,
-                    })
+                    self._stored.influxdb_admin_info = json.dumps(
+                        {
+                            "ingress": ingress,
+                            "port": port,
+                            "user": user,
+                            "password": password,
+                        }
+                    )
 
                     # Influxdb client
                     client = influxdb.InfluxDBClient(
@@ -103,37 +98,26 @@ class InfluxDB(Object):
                     influx_slurm_password = random_string()
 
                     # Only create the user and db if they don't already exist
-                    users = [
-                        db['user']
-                        for db in client.get_list_users()
-                    ]
+                    users = [db["user"] for db in client.get_list_users()]
                     if self._INFLUX_USER not in users:
-                        client.create_user(
-                            self._INFLUX_DATABASE,
-                            influx_slurm_password
-                        )
+                        client.create_user(self._INFLUX_DATABASE, influx_slurm_password)
 
-                    databases = [
-                        db['name']
-                        for db in client.get_list_database()
-                    ]
+                    databases = [db["name"] for db in client.get_list_database()]
                     if self._INFLUX_DATABASE not in databases:
                         client.create_database(self._INFLUX_DATABASE)
 
                     client.grant_privilege(
-                        self._INFLUX_PRIVILEGE,
-                        self._INFLUX_DATABASE,
-                        self._INFLUX_USER
+                        self._INFLUX_PRIVILEGE, self._INFLUX_DATABASE, self._INFLUX_USER
                     )
 
                     # Dump influxdb_info to json and set it to state
                     self._stored.influxdb_info = json.dumps(
                         {
-                            'ingress': ingress,
-                            'port': port,
-                            'user': self._INFLUX_USER,
-                            'password': influx_slurm_password,
-                            'database': self._INFLUX_DATABASE,
+                            "ingress": ingress,
+                            "port": port,
+                            "user": self._INFLUX_USER,
+                            "password": influx_slurm_password,
+                            "database": self._INFLUX_DATABASE,
                         }
                     )
                     self.on.influxdb_available.emit()
@@ -142,27 +126,19 @@ class InfluxDB(Object):
         """Remove the database and user from influxdb."""
         if self.framework.model.unit.is_leader():
             if self._stored.influxdb_admin_info:
-                influxdb_admin_info = json.loads(
-                    self._stored.influxdb_admin_info
-                )
+                influxdb_admin_info = json.loads(self._stored.influxdb_admin_info)
 
                 client = influxdb.InfluxDBClient(
-                    influxdb_admin_info['ingress'],
-                    influxdb_admin_info['port'],
-                    influxdb_admin_info['user'],
-                    influxdb_admin_info['password'],
+                    influxdb_admin_info["ingress"],
+                    influxdb_admin_info["port"],
+                    influxdb_admin_info["user"],
+                    influxdb_admin_info["password"],
                 )
-                databases = [
-                    db['name']
-                    for db in client.get_list_database()
-                ]
+                databases = [db["name"] for db in client.get_list_database()]
                 if self._INFLUX_DATABASE in databases:
                     client.drop_database(self._INFLUX_DATABASE)
 
-                users = [
-                    db['user']
-                    for db in client.get_list_users()
-                ]
+                users = [db["user"] for db in client.get_list_users()]
                 if self._INFLUX_USER in users:
                     client.drop_user(self._INFLUX_USER)
 

--- a/charm-slurm-configurator/src/interface_nhc.py
+++ b/charm-slurm-configurator/src/interface_nhc.py
@@ -2,13 +2,7 @@
 """NhcRequires."""
 import json
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 
 class NhcBinAvailableEvent(EventBase):
@@ -37,11 +31,11 @@ class Nhc(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
     def _on_relation_created(self, event):
@@ -51,9 +45,9 @@ class Nhc(Object):
 
         if self.framework.model.unit.is_leader():
             my_app_data = event.relation.data[self.model.app]
-            my_app_data['slurm_conf'] = slurm_conf
-            my_app_data['sinfo'] = sinfo
-            my_app_data['scontrol'] = scontrol
+            my_app_data["slurm_conf"] = slurm_conf
+            my_app_data["sinfo"] = sinfo
+            my_app_data["scontrol"] = scontrol
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
@@ -61,26 +55,22 @@ class Nhc(Object):
             event.defer()
             return
 
-        nhc_bin_path = event_app_data.get('nhc_bin')
-        nhc_health_check_interval = event_app_data.get('health_check_interval')
-        nhc_health_check_node_state = event_app_data.get(
-            'health_check_node_state'
-        )
+        nhc_bin_path = event_app_data.get("nhc_bin")
+        nhc_health_check_interval = event_app_data.get("health_check_interval")
+        nhc_health_check_node_state = event_app_data.get("health_check_node_state")
 
-        deps = [
-            nhc_bin_path,
-            nhc_health_check_interval,
-            nhc_health_check_node_state
-        ]
+        deps = [nhc_bin_path, nhc_health_check_interval, nhc_health_check_node_state]
         if not all(deps):
             event.defer()
             return
 
-        self._stored.nhc_info = json.dumps({
-            'nhc_bin': nhc_bin_path,
-            'health_check_interval': nhc_health_check_interval,
-            'health_check_node_state': nhc_health_check_node_state,
-        })
+        self._stored.nhc_info = json.dumps(
+            {
+                "nhc_bin": nhc_bin_path,
+                "health_check_interval": nhc_health_check_interval,
+                "health_check_node_state": nhc_health_check_node_state,
+            }
+        )
         self.on.nhc_bin_available.emit()
 
     def get_nhc_info(self):

--- a/charm-slurm-configurator/src/interface_prolog_epilog.py
+++ b/charm-slurm-configurator/src/interface_prolog_epilog.py
@@ -3,14 +3,7 @@
 import json
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 logger = logging.getLogger()
 
@@ -45,17 +38,15 @@ class PrologEpilog(Object):
             prolog_epilog=str(),
         )
         self.framework.observe(
-            self._charm.on[relation_name].relation_changed,
-            self._on_relation_changed
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
         )
         self.framework.observe(
-            self._charm.on[relation_name].relation_broken,
-            self._on_relation_broken
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
         )
 
     def _on_relation_changed(self, event):
-        prolog = event.relation.data[event.unit].get('prolog', None)
-        epilog = event.relation.data[event.unit].get('epilog', None)
+        prolog = event.relation.data[event.unit].get("prolog", None)
+        epilog = event.relation.data[event.unit].get("epilog", None)
 
         if not prolog:
             event.defer()
@@ -65,10 +56,9 @@ class PrologEpilog(Object):
             event.defer()
             return
 
-        self._stored.prolog_epilog = json.dumps({
-            'slurmctld_epilog_path': epilog,
-            'slurmctld_prolog_path': prolog
-        })
+        self._stored.prolog_epilog = json.dumps(
+            {"slurmctld_epilog_path": epilog, "slurmctld_prolog_path": prolog}
+        )
 
         self.on.prolog_epilog_available.emit()
 

--- a/charm-slurm-configurator/src/interface_slurmctld.py
+++ b/charm-slurm-configurator/src/interface_slurmctld.py
@@ -69,7 +69,7 @@ class Slurmctld(Object):
             event.defer()
             return
         # Get the munge_key from the slurm_ops_manager and set it to the app
-        # data on the relation to be retrieved on the other side by slurmdbd.
+        # data on the relation to be retrieved on the other side by slurmctld.
         app_relation_data = event.relation.data[self.model.app]
         app_relation_data['munge_key'] = self._charm.get_munge_key()
 
@@ -97,6 +97,11 @@ class Slurmctld(Object):
     @property
     def _relation(self):
         return self.framework.model.get_relation(self._relation_name)
+
+    @property
+    def is_joined(self):
+        """Return True if self._relation is not None."""
+        return self._relation is not None
 
     def get_slurmctld_info(self):
         """Return the slurmctld_info."""

--- a/charm-slurm-configurator/src/interface_slurmctld.py
+++ b/charm-slurm-configurator/src/interface_slurmctld.py
@@ -136,4 +136,11 @@ class Slurmctld(Object):
         relations = self._charm.framework.model.relations["slurmctld"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
-            app_relation_data["restart_slurmctld_hash"] = str(uuid.uuid4())
+            app_relation_data["restart_slurmctld_uuid"] = str(uuid.uuid4())
+
+    def scontrol_reconfigure(self):
+        """Send a signal to slurmctld to run 'scontrol reconfigure'."""
+        relations = self._charm.framework.model.relations["slurmctld"]
+        for relation in relations:
+            app_relation_data = relation.data[self.model.app]
+            app_relation_data["scontrol_reconfigure_uuid"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/interface_slurmctld.py
+++ b/charm-slurm-configurator/src/interface_slurmctld.py
@@ -3,14 +3,7 @@
 import json
 import logging
 
-
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -44,22 +37,22 @@ class Slurmctld(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_departed,
-            self._on_relation_departed
+            self._on_relation_departed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_created(self, event):
@@ -71,12 +64,12 @@ class Slurmctld(Object):
         # Get the munge_key from the slurm_ops_manager and set it to the app
         # data on the relation to be retrieved on the other side by slurmctld.
         app_relation_data = event.relation.data[self.model.app]
-        app_relation_data['munge_key'] = self._charm.get_munge_key()
+        app_relation_data["munge_key"] = self._charm.get_munge_key()
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
-            slurmctld_info = event_app_data.get('slurmctld_info')
+            slurmctld_info = event_app_data.get("slurmctld_info")
             if slurmctld_info:
                 self._charm.set_slurmctld_available(True)
                 self.on.slurmctld_available.emit()
@@ -89,7 +82,7 @@ class Slurmctld(Object):
 
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():
-            event.relation.data[self.model.app]['munge_key'] = ""
+            event.relation.data[self.model.app]["munge_key"] = ""
             self.set_slurm_config_on_app_relation_data("")
         self._charm.set_slurmctld_available(False)
         self.on.slurmctld_unavailable.emit()
@@ -111,7 +104,7 @@ class Slurmctld(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    slurmctld_info = app_data.get('slurmctld_info')
+                    slurmctld_info = app_data.get("slurmctld_info")
                     if slurmctld_info:
                         return json.loads(slurmctld_info)
         return None
@@ -126,10 +119,10 @@ class Slurmctld(Object):
         to observe the relation-changed event so they can acquire and
         render the updated slurm_config.
         """
-        relations = self._charm.framework.model.relations['slurmctld']
+        relations = self._charm.framework.model.relations["slurmctld"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
             if slurm_config != "":
-                app_relation_data['slurm_config'] = json.dumps(slurm_config)
+                app_relation_data["slurm_config"] = json.dumps(slurm_config)
             else:
-                app_relation_data['slurm_config'] = slurm_config
+                app_relation_data["slurm_config"] = slurm_config

--- a/charm-slurm-configurator/src/interface_slurmctld.py
+++ b/charm-slurm-configurator/src/interface_slurmctld.py
@@ -2,8 +2,12 @@
 """Slurmdbd."""
 import json
 import logging
+import uuid
 
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.framework import (
+    EventBase, EventSource, Object, ObjectEvents,
+)
+
 
 logger = logging.getLogger()
 
@@ -126,3 +130,10 @@ class Slurmctld(Object):
                 app_relation_data["slurm_config"] = json.dumps(slurm_config)
             else:
                 app_relation_data["slurm_config"] = slurm_config
+
+    def restart_slurmctld(self):
+        """Send a restart signal to related slurmctld application."""
+        relations = self._charm.framework.model.relations["slurmctld"]
+        for relation in relations:
+            app_relation_data = relation.data[self.model.app]
+            app_relation_data["restart_slurmctld_hash"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -4,13 +4,8 @@ import json
 import logging
 import socket
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
+
 from utils import get_inventory
 
 logger = logging.getLogger()
@@ -50,15 +45,15 @@ class Slurmd(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_created(self, event):
@@ -70,12 +65,12 @@ class Slurmd(Object):
         # Get the munge_key from the slurm_ops_manager and set it to the app
         # data on the relation to be retrieved on the other side by slurmdbd.
         app_relation_data = event.relation.data[self.model.app]
-        app_relation_data['munge_key'] = self._charm.get_munge_key()
+        app_relation_data["munge_key"] = self._charm.get_munge_key()
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
-            slurmd_info = event_app_data.get('slurmd_info')
+            slurmd_info = event_app_data.get("slurmd_info")
             if slurmd_info:
                 self._charm.set_slurmd_available(True)
                 self.on.slurmd_available.emit()
@@ -85,7 +80,7 @@ class Slurmd(Object):
 
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():
-            event.relation.data[self.model.app]['munge_key'] = ""
+            event.relation.data[self.model.app]["munge_key"] = ""
             self.set_slurm_config_on_app_relation_data("")
         self._charm.set_slurmd_available(False)
         self.on.slurmd_unavailable.emit()
@@ -105,23 +100,23 @@ class Slurmd(Object):
         inventory = get_inventory(hostname, hostname)
 
         return {
-            'inventory': [inventory],
-            'partition_name': 'configurator',
-            'partition_state': 'INACTIVE',
-            'partition_config': ''
+            "inventory": [inventory],
+            "partition_name": "configurator",
+            "partition_state": "INACTIVE",
+            "partition_config": "",
         }
 
     def get_slurmd_info(self):
         """Return the node info for units of applications on the relation."""
         nodes_info = []
-        relations = self.framework.model.relations['slurmd']
+        relations = self.framework.model.relations["slurmd"]
 
         for relation in relations:
             app = relation.app
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    slurmd_info = app_data.get('slurmd_info')
+                    slurmd_info = app_data.get("slurmd_info")
                     if slurmd_info:
                         nodes_info.append(json.loads(slurmd_info))
 
@@ -139,7 +134,7 @@ class Slurmd(Object):
         to observe the relation-changed event so they can acquire and
         render the updated slurm_config.
         """
-        relations = self._charm.framework.model.relations['slurmd']
+        relations = self._charm.framework.model.relations["slurmd"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
-            app_relation_data['slurm_config'] = json.dumps(slurm_config)
+            app_relation_data["slurm_config"] = json.dumps(slurm_config)

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -21,15 +21,15 @@ class SlurmdBrokenEvent(EventBase):
     """Emmited when the slurmd relation is broken."""
 
 
-class SlurmdDepartedEvent(EventBase):
-    """Emmited when a slurmd unit departs."""
+#class SlurmdDepartedEvent(EventBase):
+#    """Emmited when a slurmd unit departs."""
 
 
 class SlurmdRequiresEvents(ObjectEvents):
     """SlurmClusterProviderRelationEvents."""
 
     slurmd_available = EventSource(SlurmdAvailableEvent)
-    slurmd_departed = EventSource(SlurmdDepartedEvent)
+    #slurmd_departed = EventSource(SlurmdDepartedEvent)
     slurmd_unavailable = EventSource(SlurmdBrokenEvent)
 
 
@@ -53,6 +53,10 @@ class Slurmd(Object):
             self._charm.on[self._relation_name].relation_changed,
             self._on_relation_changed,
         )
+        #self.framework.observe(
+        #    self._charm.on[self._relation_name].relation_departed,
+        #    self._on_relation_departed,
+        #)
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
             self._on_relation_broken,
@@ -79,6 +83,9 @@ class Slurmd(Object):
         else:
             event.defer()
             return
+
+    #def _on_relation_departed(self, event):
+    #    self.on.slurmd_departed.emit()
 
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():
@@ -178,4 +185,4 @@ class Slurmd(Object):
         relations = self._charm.framework.model.relations["slurmd"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
-            app_relation_data["restart_slurmd_hash"] = str(uuid.uuid4())
+            app_relation_data["restart_slurmd_uuid"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -129,7 +129,7 @@ class Slurmd(Object):
         # 1) Create a temp copy of the partitions list and iterate
         # over it.
         #
-        # 2) On each pass we get create a temp copy of the partition itself.
+        # 2) On each pass create a temp copy of the partition itself.
         #
         # 3) Get the inventory from the temp partition and iterate over it to
         # ensure we have unique entries.

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 """Slurmd."""
 import copy
+import uuid
 import json
 import logging
 import socket
@@ -71,8 +72,8 @@ class Slurmd(Object):
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
-            slurmd_info = event_app_data.get("partition_info")
-            if slurmd_info:
+            partition_info = event_app_data.get("partition_info")
+            if partition_info:
                 self._charm.set_slurmd_available(True)
                 self.on.slurmd_available.emit()
         else:
@@ -171,3 +172,10 @@ class Slurmd(Object):
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
             app_relation_data["slurm_config"] = json.dumps(slurm_config)
+
+    def restart_slurmd(self):
+        """Send a restart signal to related slurmd applications."""
+        relations = self._charm.framework.model.relations["slurmd"]
+        for relation in relations:
+            app_relation_data = relation.data[self.model.app]
+            app_relation_data["restart_slurmd_hash"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -71,7 +71,7 @@ class Slurmd(Object):
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
-            slurmd_info = event_app_data.get("slurmd_info")
+            slurmd_info = event_app_data.get("partition_info")
             if slurmd_info:
                 self._charm.set_slurmd_available(True)
                 self.on.slurmd_available.emit()
@@ -117,9 +117,9 @@ class Slurmd(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    slurmd_info = app_data.get("slurmd_info")
-                    if slurmd_info:
-                        partitions.append(json.loads(slurmd_info))
+                    partition_info = app_data.get("partition_info")
+                    if partition_info:
+                        partitions.append(json.loads(partition_info))
 
         slurm_configurator = self._assemble_slurm_configurator_inventory()
         partitions.append(slurm_configurator)

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -53,10 +53,6 @@ class Slurmd(Object):
             self._on_relation_created
         )
         self.framework.observe(
-            self._charm.on[self._relation_name].relation_joined,
-            self._on_relation_joined
-        )
-        self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
             self._on_relation_changed
         )

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -76,15 +76,6 @@ class Slurmd(Object):
         app_relation_data = event.relation.data[self.model.app]
         app_relation_data['munge_key'] = self._charm.get_munge_key()
 
-    def _on_relation_joined(self, event):
-        partition_name = event.relation.data[event.app].get('partition_name')
-        if not partition_name:
-            event.defer()
-            return
-
-        if not self._charm.get_default_partition():
-            self._charm.set_default_partition(partition_name)
-
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
@@ -110,7 +101,7 @@ class Slurmd(Object):
         return {
             'inventory': [inventory],
             'partition_name': 'configurator',
-            'partition_state': 'DRAIN',
+            'partition_state': 'INACTIVE',
             'partition_config': ''
         }
 

--- a/charm-slurm-configurator/src/interface_slurmd.py
+++ b/charm-slurm-configurator/src/interface_slurmd.py
@@ -21,15 +21,10 @@ class SlurmdBrokenEvent(EventBase):
     """Emmited when the slurmd relation is broken."""
 
 
-#class SlurmdDepartedEvent(EventBase):
-#    """Emmited when a slurmd unit departs."""
-
-
 class SlurmdRequiresEvents(ObjectEvents):
     """SlurmClusterProviderRelationEvents."""
 
     slurmd_available = EventSource(SlurmdAvailableEvent)
-    #slurmd_departed = EventSource(SlurmdDepartedEvent)
     slurmd_unavailable = EventSource(SlurmdBrokenEvent)
 
 
@@ -53,10 +48,6 @@ class Slurmd(Object):
             self._charm.on[self._relation_name].relation_changed,
             self._on_relation_changed,
         )
-        #self.framework.observe(
-        #    self._charm.on[self._relation_name].relation_departed,
-        #    self._on_relation_departed,
-        #)
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
             self._on_relation_broken,
@@ -83,9 +74,6 @@ class Slurmd(Object):
         else:
             event.defer()
             return
-
-    #def _on_relation_departed(self, event):
-    #    self.on.slurmd_departed.emit()
 
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():

--- a/charm-slurm-configurator/src/interface_slurmdbd.py
+++ b/charm-slurm-configurator/src/interface_slurmdbd.py
@@ -97,6 +97,11 @@ class Slurmdbd(Object):
     def _relation(self):
         return self.framework.model.get_relation(self._relation_name)
 
+    @property
+    def is_joined(self):
+        """Return True if self._relation is not None."""
+        return self._relation is not None
+
     def get_slurmdbd_info(self):
         """Return the slurmdbd_info."""
         relation = self._relation

--- a/charm-slurm-configurator/src/interface_slurmdbd.py
+++ b/charm-slurm-configurator/src/interface_slurmdbd.py
@@ -3,14 +3,7 @@
 import json
 import logging
 
-
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -44,22 +37,22 @@ class Slurmdbd(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_departed,
-            self._on_relation_departed
+            self._on_relation_departed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_created(self, event):
@@ -71,12 +64,12 @@ class Slurmdbd(Object):
         # Get the munge_key from the slurm_ops_manager and set it to the app
         # data on the relation to be retrieved on the other side by slurmdbd.
         munge_key = self._charm.get_munge_key()
-        event.relation.data[self.model.app]['munge_key'] = munge_key
+        event.relation.data[self.model.app]["munge_key"] = munge_key
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:
-            slurmdbd_info = event_app_data.get('slurmdbd_info')
+            slurmdbd_info = event_app_data.get("slurmdbd_info")
             if slurmdbd_info:
                 self._charm.set_slurmdbd_available(True)
                 self.on.slurmdbd_available.emit()
@@ -89,7 +82,7 @@ class Slurmdbd(Object):
 
     def _on_relation_broken(self, event):
         if self.framework.model.unit.is_leader():
-            event.relation.data[self.model.app]['munge_key'] = ""
+            event.relation.data[self.model.app]["munge_key"] = ""
         self._charm.set_slurmdbd_available(False)
         self.on.slurmdbd_unavailable.emit()
 
@@ -110,7 +103,7 @@ class Slurmdbd(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    slurmdbd_info = app_data.get('slurmdbd_info')
+                    slurmdbd_info = app_data.get("slurmdbd_info")
                     if slurmdbd_info:
                         return json.loads(slurmdbd_info)
         return None

--- a/charm-slurm-configurator/src/interface_slurmdbd.py
+++ b/charm-slurm-configurator/src/interface_slurmdbd.py
@@ -5,6 +5,7 @@ import logging
 
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
+
 logger = logging.getLogger()
 
 

--- a/charm-slurm-configurator/src/interface_slurmrestd.py
+++ b/charm-slurm-configurator/src/interface_slurmrestd.py
@@ -2,6 +2,7 @@
 """SlurmrestdProvides."""
 import json
 import logging
+import uuid
 
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
@@ -62,3 +63,10 @@ class Slurmrestd(Object):
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
             app_relation_data["slurm_config"] = json.dumps(slurm_config)
+
+    def restart_slurmrestd(self):
+        """Send a restart signal to related slurmd applications."""
+        relations = self._charm.framework.model.relations["slurmrestd"]
+        for relation in relations:
+            app_relation_data = relation.data[self.model.app]
+            app_relation_data["restart_slurmrestd_hash"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/interface_slurmrestd.py
+++ b/charm-slurm-configurator/src/interface_slurmrestd.py
@@ -3,13 +3,7 @@
 import json
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -40,12 +34,10 @@ class Slurmrestd(Object):
 
         self.charm = charm
         self.framework.observe(
-            charm.on[relation_name].relation_created,
-            self._on_relation_created
+            charm.on[relation_name].relation_created, self._on_relation_created
         )
         self.framework.observe(
-            charm.on[relation_name].relation_broken,
-            self._on_relation_broken
+            charm.on[relation_name].relation_broken, self._on_relation_broken
         )
 
     def _on_relation_created(self, event):
@@ -66,7 +58,7 @@ class Slurmrestd(Object):
         to observe the relation-changed event so they can acquire and
         render the updated slurm_config.
         """
-        relations = self.charm.framework.model.relations['slurmrestd']
+        relations = self.charm.framework.model.relations["slurmrestd"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
-            app_relation_data['slurm_config'] = json.dumps(slurm_config)
+            app_relation_data["slurm_config"] = json.dumps(slurm_config)

--- a/charm-slurm-configurator/src/interface_slurmrestd.py
+++ b/charm-slurm-configurator/src/interface_slurmrestd.py
@@ -69,4 +69,4 @@ class Slurmrestd(Object):
         relations = self._charm.framework.model.relations["slurmrestd"]
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
-            app_relation_data["restart_slurmrestd_hash"] = str(uuid.uuid4())
+            app_relation_data["restart_slurmrestd_uuid"] = str(uuid.uuid4())

--- a/charm-slurm-configurator/src/utils.py
+++ b/charm-slurm-configurator/src/utils.py
@@ -9,6 +9,7 @@ import sys
 
 def lscpu():
     """Return lscpu as a python dictionary."""
+
     def format_key(lscpu_key):
         key_lower = lscpu_key.lower()
         replace_hyphen = key_lower.replace("-", "_")
@@ -16,7 +17,7 @@ def lscpu():
         replace_rparen = replace_lparen.replace(")", "")
         return replace_rparen.replace(" ", "_")
 
-    lscpu_out = subprocess.check_output(['lscpu'])
+    lscpu_out = subprocess.check_output(["lscpu"])
     lscpu_lines = lscpu_out.decode().strip().split("\n")
 
     return {
@@ -30,10 +31,10 @@ def cpu_info():
     ls_cpu = lscpu()
 
     return {
-        'cpus': ls_cpu['cpus'],
-        'threads_per_core': ls_cpu['threads_per_core'],
-        'cores_per_socket': ls_cpu['cores_per_socket'],
-        'sockets_per_board': ls_cpu['sockets'],
+        "cpus": ls_cpu["cpus"],
+        "threads_per_core": ls_cpu["threads_per_core"],
+        "cores_per_socket": ls_cpu["cores_per_socket"],
+        "sockets_per_board": ls_cpu["sockets"],
     }
 
 
@@ -42,8 +43,7 @@ def free_m():
     real_mem = ""
     try:
         real_mem = subprocess.check_output(
-            "free -m | grep -oP '\\d+' | head -n 1",
-            shell=True
+            "free -m | grep -oP '\\d+' | head -n 1", shell=True
         )
     except subprocess.CalledProcessError as e:
         print(e)
@@ -60,8 +60,10 @@ def lspci_nvidia():
             subprocess.check_output(
                 "lspci | grep -i nvidia | awk '{print $1}' "
                 "| cut -d : -f 1 | sort -u | wc -l",
-                shell=True
-            ).decode().strip()
+                shell=True,
+            )
+            .decode()
+            .strip()
         )
     except subprocess.CalledProcessError as e:
         print(e)
@@ -77,31 +79,29 @@ def lspci_nvidia():
 def get_inventory(node_name, node_addr):
     """Assemble and return the node info."""
     inventory = {
-        'node_name': node_name,
-        'node_addr': node_addr,
-        'state': "UNKNOWN",
-        'real_memory': free_m(),
+        "node_name": node_name,
+        "node_addr": node_addr,
+        "state": "UNKNOWN",
+        "real_memory": free_m(),
         **cpu_info(),
     }
 
     gpus = lspci_nvidia()
-    if (gpus > 0):
-        inventory['gres'] = gpus
+    if gpus > 0:
+        inventory["gres"] = gpus
     return inventory
 
 
 def _related_units(relid):
     """List of related units."""
-    units_cmd_line = ['relation-list', '--format=json', '-r', relid]
-    return json.loads(
-        subprocess.check_output(units_cmd_line).decode('UTF-8')) or []
+    units_cmd_line = ["relation-list", "--format=json", "-r", relid]
+    return json.loads(subprocess.check_output(units_cmd_line).decode("UTF-8")) or []
 
 
 def _relation_ids(reltype):
     """List of relation_ids."""
-    relid_cmd_line = ['relation-ids', '--format=json', reltype]
-    return json.loads(
-        subprocess.check_output(relid_cmd_line).decode('UTF-8')) or []
+    relid_cmd_line = ["relation-ids", "--format=json", reltype]
+    return json.loads(subprocess.check_output(relid_cmd_line).decode("UTF-8")) or []
 
 
 def get_active_units(relation_name):
@@ -119,7 +119,6 @@ def random_string(length=10):
     for i in range(length):
         random_integer = random.randint(97, 97 + 26 - 1)
         flip_bit = random.randint(0, 1)
-        random_integer = \
-            random_integer - 32 if flip_bit == 1 else random_integer
-        random_str += (chr(random_integer))
+        random_integer = random_integer - 32 if flip_bit == 1 else random_integer
+        random_str += chr(random_integer)
     return random_str

--- a/charm-slurmctld/config.yaml
+++ b/charm-slurmctld/config.yaml
@@ -1,4 +1,9 @@
 options:
+  snapstore-channel:
+    type: string
+    default: "--stable"
+    description:
+      'Snap store channel to install the slurm snap from.'
   nagios_context:
     default: "juju"
     type: string

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v15
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -25,6 +25,7 @@ class SlurmctldCharm(CharmBase):
 
         self._stored.set_default(
             munge_key=str(),
+            munge_key_available=False,
             slurmctld_controller_type=str(),
         )
 
@@ -38,6 +39,7 @@ class SlurmctldCharm(CharmBase):
         event_handler_bindings = {
             self.on.install: self._on_install,
             self._slurmctld.on.slurm_config_available: self._on_check_status_and_write_config,
+            self._slurmctld.on.munge_key_available: self._on_write_munge_key,
             self._slurmctld_peer.on.slurmctld_peer_available: self._on_slurmctld_peer_available,
         }
         for event, handler in event_handler_bindings.items():
@@ -46,10 +48,18 @@ class SlurmctldCharm(CharmBase):
     def _on_install(self, event):
         self._slurm_manager.install()
         self._stored.slurm_installed = True
-        self.unit.status = ActiveStatus("Slurm Installed")
+        self.unit.status = ActiveStatus("Slurm installed")
 
     def _on_upgrade(self, event):
         self._slurm_manager.upgrade()
+
+    def _on_write_munge_key(self, event):
+        if not self._stored.slurm_installed:
+            event.defer()
+            return
+        munge_key = self._stored.munge_key
+        self._slurm_manager.configure_munge_key(munge_key)
+        self._stored.munge_key_available = True
 
     def _on_slurmctld_peer_available(self, event):
         if self.framework.model.unit.is_leader():
@@ -64,40 +74,33 @@ class SlurmctldCharm(CharmBase):
             return
 
     def _on_check_status_and_write_config(self, event):
-        if not self._check_status():
-            event.defer()
-            return
-
-        slurm_config = self._slurmctld.get_slurm_config_from_relation()
+        slurm_config = self._check_status()
         if not slurm_config:
             event.defer()
             return
 
-        munge_key = self._stored.munge_key
-        if not munge_key:
-            event.defer()
-            return
-
         self._slurm_manager.render_config_and_restart(
-            {**slurm_config, "munge_key": munge_key}
+            slurm_config
         )
-        self.unit.status = ActiveStatus("Slurmctld Available")
+        self.unit.status = ActiveStatus("slurmctld available")
 
     def _check_status(self):
-        munge_key = self._stored.munge_key
+        munge_key_available = self._stored.munge_key_available
         slurm_installed = self._stored.slurm_installed
         slurm_config = self._slurmctld.get_slurm_config_from_relation()
 
-        if not (munge_key and slurm_installed and slurm_config):
-            if not munge_key:
-                self.unit.status = BlockedStatus("NEED RELATION TO SLURM CONFIGURATOR")
+        if not (munge_key_available and slurm_installed and slurm_config):
+            if not munge_key_available:
+                self.unit.status = BlockedStatus(
+                    "NEED RELATION TO SLURM CONFIGURATOR"
+                )
             elif not slurm_config:
                 self.unit.status = BlockedStatus("WAITING ON SLURM CONFIG")
             else:
                 self.unit.status = BlockedStatus("SLURM NOT INSTALLED")
-            return False
+            return None
         else:
-            return True
+            return slurm_config
 
     def set_munge_key(self, munge_key):
         """Set the munge_key in _stored state."""

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -47,7 +47,7 @@ class SlurmctldCharm(CharmBase):
             self.framework.observe(event, handler)
 
     def _on_install(self, event):
-        self._slurm_manager.install()
+        self._slurm_manager.install(self.config["snapstore-channel"])
         self._stored.slurm_installed = True
         self.unit.status = ActiveStatus("slurm snap successfully installed")
 

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 """SlurmctldCharm."""
 import logging
-import json
 
 from interface_slurmctld import Slurmctld
 from interface_slurmctld_peer import SlurmctldPeer

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -8,12 +8,8 @@ from nrpe_external_master import Nrpe
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-)
+from ops.model import ActiveStatus, BlockedStatus
 from slurm_ops_manager import SlurmManager
-
 
 logger = logging.getLogger()
 
@@ -41,12 +37,8 @@ class SlurmctldCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
-
-            self._slurmctld.on.slurm_config_available:
-            self._on_check_status_and_write_config,
-
-            self._slurmctld_peer.on.slurmctld_peer_available:
-            self._on_slurmctld_peer_available,
+            self._slurmctld.on.slurm_config_available: self._on_check_status_and_write_config,
+            self._slurmctld_peer.on.slurmctld_peer_available: self._on_slurmctld_peer_available,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -87,10 +79,7 @@ class SlurmctldCharm(CharmBase):
             return
 
         self._slurm_manager.render_config_and_restart(
-            {
-                **slurm_config,
-                'munge_key': munge_key
-            }
+            {**slurm_config, "munge_key": munge_key}
         )
         self.unit.status = ActiveStatus("Slurmctld Available")
 
@@ -101,13 +90,9 @@ class SlurmctldCharm(CharmBase):
 
         if not (munge_key and slurm_installed and slurm_config):
             if not munge_key:
-                self.unit.status = BlockedStatus(
-                    "NEED RELATION TO SLURM CONFIGURATOR"
-                )
+                self.unit.status = BlockedStatus("NEED RELATION TO SLURM CONFIGURATOR")
             elif not slurm_config:
-                self.unit.status = BlockedStatus(
-                    "WAITING ON SLURM CONFIG"
-                )
+                self.unit.status = BlockedStatus("WAITING ON SLURM CONFIG")
             else:
                 self.unit.status = BlockedStatus("SLURM NOT INSTALLED")
             return False

--- a/charm-slurmctld/src/interface_slurmctld.py
+++ b/charm-slurmctld/src/interface_slurmctld.py
@@ -3,13 +3,7 @@
 import json
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -25,10 +19,8 @@ class SlurmConfiguratorUnAvailableEvent(EventBase):
 class SlurmctldRelationEvents(ObjectEvents):
     """Slurmctld relation events."""
 
-    slurm_config_available = \
-        EventSource(SlurmConfigAvailableEvent)
-    slurm_configurator_unavailable = \
-        EventSource(SlurmConfiguratorUnAvailableEvent)
+    slurm_config_available = EventSource(SlurmConfigAvailableEvent)
+    slurm_configurator_unavailable = EventSource(SlurmConfiguratorUnAvailableEvent)
 
 
 class Slurmctld(Object):
@@ -44,15 +36,15 @@ class Slurmctld(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
         self.framework.observe(
             self._charm.on[self._relation_name].relation_departed,
-            self._on_relation_departed
+            self._on_relation_departed,
         )
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_changed(self, event):
@@ -62,13 +54,13 @@ class Slurmctld(Object):
             event.defer()
             return
 
-        munge_key = event_app_data.get('munge_key')
+        munge_key = event_app_data.get("munge_key")
         if not munge_key:
             event.defer()
             return
         self._charm.set_munge_key(munge_key)
 
-        slurm_config = event_app_data.get('slurm_config')
+        slurm_config = event_app_data.get("slurm_config")
         if not slurm_config:
             event.defer()
             return
@@ -92,15 +84,15 @@ class Slurmctld(Object):
 
     def set_slurmctld_info_on_app_relation_data(self, slurmctld_info):
         """Set slurmctld_info."""
-        relations = self.framework.model.relations['slurmctld']
+        relations = self.framework.model.relations["slurmctld"]
         # Iterate over each of the relations setting the relation data.
         for relation in relations:
             if slurmctld_info != "":
-                relation.data[self.model.app]['slurmctld_info'] = json.dumps(
+                relation.data[self.model.app]["slurmctld_info"] = json.dumps(
                     slurmctld_info
                 )
             else:
-                relation.data[self.model.app]['slurmctld_info'] = ""
+                relation.data[self.model.app]["slurmctld_info"] = ""
 
     def get_slurm_config_from_relation(self):
         """Return slurm_config."""
@@ -110,8 +102,8 @@ class Slurmctld(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    if app_data.get('slurm_config'):
-                        return json.loads(app_data['slurm_config'])
+                    if app_data.get("slurm_config"):
+                        return json.loads(app_data["slurm_config"])
         return None
 
     def is_slurm_config_available(self):
@@ -122,6 +114,6 @@ class Slurmctld(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    if app_data.get('slurm_config'):
+                    if app_data.get("slurm_config"):
                         return True
         return False

--- a/charm-slurmctld/src/interface_slurmctld_peer.py
+++ b/charm-slurmctld/src/interface_slurmctld_peer.py
@@ -5,13 +5,7 @@ import json
 import logging
 import subprocess
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -39,17 +33,17 @@ class SlurmctldPeer(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_departed,
-            self._on_relation_departed
+            self._on_relation_departed,
         )
 
     def _on_relation_created(self, event):
@@ -57,8 +51,8 @@ class SlurmctldPeer(Object):
         relation = self.framework.model.get_relation(self._relation_name)
         unit_relation_data = relation.data[self.model.unit]
 
-        unit_relation_data['hostname'] = self._charm.get_hostname()
-        unit_relation_data['port'] = self._charm.get_port()
+        unit_relation_data["hostname"] = self._charm.get_hostname()
+        unit_relation_data["port"] = self._charm.get_port()
 
         # Call _on_relation_changed to assemble the slurmctld_info and
         # emit the slurmctld_peer_available event.
@@ -78,8 +72,8 @@ class SlurmctldPeer(Object):
             slurmctld_peers = _get_active_peers()
             slurmctld_peers_tmp = copy.deepcopy(slurmctld_peers)
 
-            active_controller = app_relation_data.get('active_controller')
-            backup_controller = app_relation_data.get('backup_controller')
+            active_controller = app_relation_data.get("active_controller")
+            backup_controller = app_relation_data.get("backup_controller")
 
             # Account for the active controller
             # In this case, tightly couple the active controller to the leader.
@@ -87,7 +81,7 @@ class SlurmctldPeer(Object):
             # If we are the leader but are not the active controller,
             # then the previous leader or active controller must have died.
             if active_controller != self.model.unit.name:
-                app_relation_data['active_controller'] = self.model.unit.name
+                app_relation_data["active_controller"] = self.model.unit.name
 
             # Account for the backup and standby controllers
             #
@@ -105,41 +99,40 @@ class SlurmctldPeer(Object):
                 # slurmctld_peers > 0 and try to promote a standby to a backup.
                 if backup_controller in slurmctld_peers:
                     slurmctld_peers_tmp.remove(backup_controller)
-                    app_relation_data['standby_controllers'] = json.dumps(
+                    app_relation_data["standby_controllers"] = json.dumps(
                         slurmctld_peers_tmp
                     )
                 else:
                     if len(slurmctld_peers) > 0:
-                        app_relation_data['backup_controller'] = \
-                            slurmctld_peers_tmp.pop()
-                        app_relation_data['standby_controllers'] = json.dumps(
+                        app_relation_data[
+                            "backup_controller"
+                        ] = slurmctld_peers_tmp.pop()
+                        app_relation_data["standby_controllers"] = json.dumps(
                             slurmctld_peers_tmp
                         )
                     else:
-                        app_relation_data['backup_controller'] = ""
-                        app_relation_data['standby_controllers'] = json.dumps(
-                            []
-                        )
+                        app_relation_data["backup_controller"] = ""
+                        app_relation_data["standby_controllers"] = json.dumps([])
             else:
                 if len(slurmctld_peers) > 0:
-                    app_relation_data['backup_controller'] = \
-                        slurmctld_peers_tmp.pop()
-                    app_relation_data['standby_controllers'] = json.dumps(
+                    app_relation_data["backup_controller"] = slurmctld_peers_tmp.pop()
+                    app_relation_data["standby_controllers"] = json.dumps(
                         slurmctld_peers_tmp
                     )
                 else:
-                    app_relation_data['standby_controllers'] = json.dumps([])
+                    app_relation_data["standby_controllers"] = json.dumps([])
 
             ctxt = {}
-            backup_controller = app_relation_data.get('backup_controller')
+            backup_controller = app_relation_data.get("backup_controller")
 
             # NOTE: We only care about the active and backup controllers.
             # Set the active controller info and check for and set the
             # backup controller information if one exists.
-            ctxt['active_controller_ingress_address'] = \
-                unit_relation_data['ingress-address']
-            ctxt['active_controller_hostname'] = self._charm.get_hostname()
-            ctxt['active_controller_port'] = str(self._charm.get_port())
+            ctxt["active_controller_ingress_address"] = unit_relation_data[
+                "ingress-address"
+            ]
+            ctxt["active_controller_hostname"] = self._charm.get_hostname()
+            ctxt["active_controller_port"] = str(self._charm.get_port())
 
             # If we have > 0 controllers (also have a backup), iterate over
             # them retrieving the info for the backup and set it along with
@@ -149,17 +142,17 @@ class SlurmctldPeer(Object):
                 for unit in relation.units:
                     if unit.name == backup_controller:
                         unit_data = relation.data[unit]
-                        ctxt['backup_controller_ingress_address'] = \
-                            unit_data['ingress-address']
-                        ctxt['backup_controller_hostname'] = \
-                            unit_data['hostname']
-                        ctxt['backup_controller_port'] = unit_data['port']
+                        ctxt["backup_controller_ingress_address"] = unit_data[
+                            "ingress-address"
+                        ]
+                        ctxt["backup_controller_hostname"] = unit_data["hostname"]
+                        ctxt["backup_controller_port"] = unit_data["port"]
             else:
-                ctxt['backup_controller_ingress_address'] = ""
-                ctxt['backup_controller_hostname'] = ""
-                ctxt['backup_controller_port'] = ""
+                ctxt["backup_controller_ingress_address"] = ""
+                ctxt["backup_controller_hostname"] = ""
+                ctxt["backup_controller_port"] = ""
 
-            app_relation_data['slurmctld_info'] = json.dumps(ctxt)
+            app_relation_data["slurmctld_info"] = json.dumps(ctxt)
             self.on.slurmctld_peer_available.emit()
 
     def _on_relation_departed(self, event):
@@ -177,7 +170,7 @@ class SlurmctldPeer(Object):
             if app:
                 app_data = relation.data.get(app)
                 if app_data:
-                    slurmctld_info = app_data.get('slurmctld_info')
+                    slurmctld_info = app_data.get("slurmctld_info")
                     if slurmctld_info:
                         return json.loads(slurmctld_info)
         return None
@@ -185,22 +178,20 @@ class SlurmctldPeer(Object):
 
 def _related_units(relid):
     """List of related units."""
-    units_cmd_line = ['relation-list', '--format=json', '-r', relid]
-    return json.loads(
-        subprocess.check_output(units_cmd_line).decode('UTF-8')) or []
+    units_cmd_line = ["relation-list", "--format=json", "-r", relid]
+    return json.loads(subprocess.check_output(units_cmd_line).decode("UTF-8")) or []
 
 
 def _relation_ids(reltype):
     """List of relation_ids."""
-    relid_cmd_line = ['relation-ids', '--format=json', reltype]
-    return json.loads(
-        subprocess.check_output(relid_cmd_line).decode('UTF-8')) or []
+    relid_cmd_line = ["relation-ids", "--format=json", reltype]
+    return json.loads(subprocess.check_output(relid_cmd_line).decode("UTF-8")) or []
 
 
 def _get_active_peers():
     """Return the active_units."""
     active_units = []
-    for rel_id in _relation_ids('slurmctld-peer'):
+    for rel_id in _relation_ids("slurmctld-peer"):
         for unit in _related_units(rel_id):
             active_units.append(unit)
     return active_units

--- a/charm-slurmd/config.yaml
+++ b/charm-slurmd/config.yaml
@@ -1,4 +1,9 @@
 options:  
+  snapstore-channel:
+    type: string
+    default: "--stable"
+    description:
+      'Snap store channel to install the slurm snap from.'
   partition-name:
     type: string
     default:

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v15
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -55,8 +55,8 @@ class SlurmdCharm(CharmBase):
             self._slurmd_peer.on.slurmd_peer_available:
             self._on_send_slurmd_info,
 
-            #self._slurmd.on.slurm_config_available:
-            #self._on_check_status_and_write_config,
+            self._slurmd.on.slurm_config_available:
+            self._on_check_status_and_write_config,
 
             self.on.set_node_state_action:
             self._on_set_node_state_action,
@@ -107,10 +107,10 @@ class SlurmdCharm(CharmBase):
             event.defer()
             return
 
-        #slurm_config = self._slurmd.get_slurm_config()
-        #if not slurm_config:
-        #    event.defer()
-        #    return
+        slurm_config = self._slurmd.get_slurm_config()
+        if not slurm_config:
+            event.defer()
+            return
 
         munge_key = self._stored.munge_key
         if not munge_key:
@@ -118,8 +118,7 @@ class SlurmdCharm(CharmBase):
             return
 
         self._slurm_manager.render_config_and_restart(
-            #{**slurm_config, 'munge_key': munge_key}
-            {'munge_key': munge_key}
+            {**slurm_config, 'munge_key': munge_key}
         )
         self.unit.status = ActiveStatus("Slurmd Available")
 

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -62,7 +62,7 @@ class SlurmdCharm(CharmBase):
             self.framework.observe(event, handler)
 
     def _on_install(self, event):
-        self._slurm_manager.install()
+        self._slurm_manager.install(self.config["snapstore-channel"])
 
         if self.model.unit.is_leader():
             self._get_set_partition_name()

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -148,7 +148,6 @@ class SlurmdCharm(CharmBase):
 
     def _on_set_partition_info_on_app_relation_data(self, event):
         """Set the slurm partition info on the application relation data."""
-
         # Only the leader can set data on the relation.
         if self.framework.model.unit.is_leader():
             # If the relation with slurm-configurator exists then set our

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -55,8 +55,8 @@ class SlurmdCharm(CharmBase):
             self._slurmd_peer.on.slurmd_peer_available:
             self._on_send_slurmd_info,
 
-            self._slurmd.on.slurm_config_available:
-            self._on_check_status_and_write_config,
+            #self._slurmd.on.slurm_config_available:
+            #self._on_check_status_and_write_config,
 
             self.on.set_node_state_action:
             self._on_set_node_state_action,
@@ -69,9 +69,9 @@ class SlurmdCharm(CharmBase):
 
         if self.model.unit.is_leader():
             self._get_set_partition_name()
-            logger.debug("LOGGING PARTITION_NAME")
-            logger.debug(self._stored.partition_name)
-
+            logger.debug(
+                f"PARTITION_NAME: {self._stored.partition_name}"
+            )
         self._stored.slurm_installed = True
         self.unit.status = ActiveStatus("Slurm Installed")
 
@@ -107,10 +107,10 @@ class SlurmdCharm(CharmBase):
             event.defer()
             return
 
-        slurm_config = self._slurmd.get_slurm_config()
-        if not slurm_config:
-            event.defer()
-            return
+        #slurm_config = self._slurmd.get_slurm_config()
+        #if not slurm_config:
+        #    event.defer()
+        #    return
 
         munge_key = self._stored.munge_key
         if not munge_key:
@@ -118,7 +118,8 @@ class SlurmdCharm(CharmBase):
             return
 
         self._slurm_manager.render_config_and_restart(
-            {**slurm_config, 'munge_key': munge_key}
+            #{**slurm_config, 'munge_key': munge_key}
+            {'munge_key': munge_key}
         )
         self.unit.status = ActiveStatus("Slurmd Available")
 

--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -195,3 +195,6 @@ class Slurmd(Object):
 
     def _store_slurmd_restart_uuid(self, restart_slurmd_uuid):
         self._stored.restart_slurmd_uuid = restart_slurmd_uuid
+
+    def _get_slurmd_restart_uuid(self):
+        return self._stored.restart_slurmd_uuid

--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -2,34 +2,53 @@
 """Slurmd."""
 import json
 
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.framework import (
+    EventBase, EventSource, Object, ObjectEvents, StoredState,
+)
 
 
 class SlurmConfigAvailableEvent(EventBase):
     """Emitted when slurm config is available."""
 
 
+class SlurmConfigUnAvailableEvent(EventBase):
+    """Emit when the relation to slurm-configurator is broken."""
+
+
 class MungeKeyAvailableEvent(EventBase):
     """Emit when the munge key has been acquired and set to the charm state."""
 
 
-class SlurmdProvidesEvents(ObjectEvents):
-    """SlurmctldProvidesEvents."""
+class RestartSlurmdEvent(EventBase):
+    """Emit when slurmd should be restarted."""
 
-    slurm_config_available = EventSource(SlurmConfigAvailableEvent)
+
+class SlurmdEvents(ObjectEvents):
+    """Slurmd emitted events."""
+
     munge_key_available = EventSource(MungeKeyAvailableEvent)
+    restart_slurmd = EventSource(RestartSlurmdEvent)
+    slurm_config_available = EventSource(SlurmConfigAvailableEvent)
+    slurm_config_unavailable = EventSource(SlurmConfigUnAvailableEvent)
 
 
 class Slurmd(Object):
     """Slurmd."""
 
-    on = SlurmdProvidesEvents()
+    _stored = StoredState()
+    on = SlurmdEvents()
 
     def __init__(self, charm, relation_name):
         """Set initial data and observe interface events."""
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
+
+        self._stored.set_default(
+            slurm_config=dict(),
+            munge_key=str(),
+            restart_slurmd_uuid=str(),
+        )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
@@ -39,6 +58,11 @@ class Slurmd(Object):
         self.framework.observe(
             self._charm.on[self._relation_name].relation_joined,
             self._on_relation_joined,
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed,
+            self._on_relation_changed,
         )
 
         self.framework.observe(
@@ -52,11 +76,11 @@ class Slurmd(Object):
         Set the partition_name on the application relation data.
         """
         partition_name = self._charm.get_partition_name()
-        if self.framework.model.unit.is_leader():
-            if not partition_name:
-                event.defer()
-                return
+        if not partition_name:
+            event.defer()
+            return
 
+        if self.framework.model.unit.is_leader():
             event.relation.data[self.model.app][
                 "partition_name"
             ] = self._charm.get_partition_name()
@@ -84,11 +108,41 @@ class Slurmd(Object):
             return
 
         # Store the munge_key in the charm's state
-        self._charm.set_munge_key(munge_key)
+        self._store_munge_key(munge_key)
         self.on.munge_key_available.emit()
 
+    def _on_relation_changed(self, event):
+        """Check for the munge_key in the relation data."""
+        event_app_data = event.relation.data.get(event.app)
+        if not event_app_data:
+            event.defer()
+            return
+
+        munge_key = event_app_data.get('munge_key')
+        restart_slurmd_uuid = event_app_data.get('restart_slurmd_uuid')
+        slurm_config = self._get_slurm_config_from_relation()
+
+        if not (munge_key and slurm_config):
+            event.defer()
+            return
+
+        # Store the munge_key in the interface StoredState if it has changed
+        if munge_key != self.get_stored_munge_key():
+            self._store_munge_key(munge_key)
+            self.on.munge_key_available.emit()
+
+        # Store the slurm_config in the interface StoredState if it has changed
+        if slurm_config != self.get_stored_slurm_config():
+            self._store_slurm_config(slurm_config)
+            self.on.slurm_config_available.emit()
+
+        if restart_slurmd_uuid:
+            if restart_slurmd_uuid != self._get_slurmd_restart_uuid():
+                self._store_slurmd_restart_uuid(restart_slurmd_uuid)
+                self.on.restart_slurmd.emit()
+
     def _on_relation_broken(self, event):
-        self.on.slurm_config_available.emit()
+        self.on.slurm_config_unavailable.emit()
 
     @property
     def _relation(self):
@@ -112,7 +166,7 @@ class Slurmd(Object):
                 partition_info
             )
 
-    def get_slurm_config(self):
+    def _get_slurm_config_from_relation(self):
         """Return slurm_config."""
         relation = self._relation
         if relation:
@@ -124,3 +178,20 @@ class Slurmd(Object):
                     if slurm_config:
                         return json.loads(slurm_config)
         return None
+
+    def _store_munge_key(self, munge_key):
+        self._stored.munge_key = munge_key
+
+    def get_stored_munge_key(self):
+        """Retrieve the munge_key from the StoredState."""
+        return self._stored.munge_key
+
+    def _store_slurm_config(self, slurm_config):
+        self._stored.slurm_config = slurm_config
+
+    def get_stored_slurm_config(self):
+        """Retrieve the slurm_config from the StoredState."""
+        return self._stored.slurm_config
+
+    def _store_slurmd_restart_uuid(self, restart_slurmd_uuid):
+        self._stored.restart_slurmd_uuid = restart_slurmd_uuid

--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -2,12 +2,7 @@
 """Slurmd."""
 import json
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 
 class SlurmConfigAvailableEvent(EventBase):
@@ -33,12 +28,12 @@ class Slurmd(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
     def _on_relation_created(self, event):
@@ -49,8 +44,9 @@ class Slurmd(Object):
                 event.defer()
                 return
 
-            event.relation.data[self.model.app]['partition_name'] = \
-                self._charm.get_partition_name()
+            event.relation.data[self.model.app][
+                "partition_name"
+            ] = self._charm.get_partition_name()
 
     def _on_relation_changed(self, event):
         """Check for the munge_key in the relation data."""
@@ -60,7 +56,7 @@ class Slurmd(Object):
             return
 
         # Get the munge_key from slurm-configurator
-        munge_key = event_app_data.get('munge_key')
+        munge_key = event_app_data.get("munge_key")
         if not munge_key:
             event.defer()
             return
@@ -88,11 +84,9 @@ class Slurmd(Object):
         slurm-configurator application(s) to observe the relation-changed
         event so they can acquire and redistribute the updated slurm config.
         """
-        relations = self._charm.framework.model.relations['slurmd']
+        relations = self._charm.framework.model.relations["slurmd"]
         for relation in relations:
-            relation.data[self.model.app]['slurmd_info'] = json.dumps(
-                slurmd_info
-            )
+            relation.data[self.model.app]["slurmd_info"] = json.dumps(slurmd_info)
 
     def get_slurm_config(self):
         """Return slurm_config."""
@@ -102,7 +96,7 @@ class Slurmd(Object):
             if app:
                 app_data = self._relation.data.get(app)
                 if app_data:
-                    slurm_config = app_data.get('slurm_config')
+                    slurm_config = app_data.get("slurm_config")
                     if slurm_config:
                         return json.loads(slurm_config)
         return None

--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -33,21 +33,14 @@ class SlurmdPeer(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._set_inventory_on_unit_data,
+            self._on_relation_created,
         )
-
-        self.framework.observe(
-            self._charm.on[self._relation_name].relation_joined,
-            self._set_inventory_on_unit_data,
-        )
-
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
             self._on_relation_changed,
         )
 
-    def _set_inventory_on_unit_data(self, event):
-        """Set our inventory on unit data."""
+    def _on_relation_created(self, event):
         node_name = self._charm.get_hostname()
         node_addr = event.relation.data[self.model.unit]["ingress-address"]
 

--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -3,15 +3,9 @@
 import json
 import logging
 
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
 from utils import get_active_units, get_inventory
-
 
 logger = logging.getLogger()
 
@@ -39,20 +33,20 @@ class SlurmdPeer(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
-            self._on_relation_created
+            self._on_relation_created,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
     def _on_relation_created(self, event):
         """Set our inventory on unit data."""
         node_name = self._charm.get_hostname()
-        node_addr = event.relation.data[self.model.unit]['ingress-address']
+        node_addr = event.relation.data[self.model.unit]["ingress-address"]
 
-        event.relation.data[self.model.unit]['inventory'] = json.dumps(
+        event.relation.data[self.model.unit]["inventory"] = json.dumps(
             get_inventory(node_name, node_addr)
         )
         if self.framework.model.unit.is_leader():
@@ -72,19 +66,17 @@ class SlurmdPeer(Object):
         peers = relation.units
 
         slurmd_info = [
-            json.loads(relation.data[peer]['inventory'])
-            for peer in peers if (
-                (peer.name in slurmd_peers) and (
-                    (relation.data.get(peer)) and (
-                        relation.data[peer].get('inventory')
-                    )
+            json.loads(relation.data[peer]["inventory"])
+            for peer in peers
+            if (
+                (peer.name in slurmd_peers)
+                and (
+                    (relation.data.get(peer)) and (relation.data[peer].get("inventory"))
                 )
             )
         ]
 
         # Add our own inventory to the slurmd_info
-        slurmd_info.append(
-            json.loads(relation.data[self.model.unit]['inventory'])
-        )
+        slurmd_info.append(json.loads(relation.data[self.model.unit]["inventory"]))
 
         return slurmd_info

--- a/charm-slurmd/src/utils.py
+++ b/charm-slurmd/src/utils.py
@@ -9,6 +9,7 @@ import sys
 
 def lscpu():
     """Return lscpu as a python dictionary."""
+
     def format_key(lscpu_key):
         key_lower = lscpu_key.lower()
         replace_hyphen = key_lower.replace("-", "_")
@@ -16,7 +17,7 @@ def lscpu():
         replace_rparen = replace_lparen.replace(")", "")
         return replace_rparen.replace(" ", "_")
 
-    lscpu_out = subprocess.check_output(['lscpu'])
+    lscpu_out = subprocess.check_output(["lscpu"])
     lscpu_lines = lscpu_out.decode().strip().split("\n")
 
     return {
@@ -30,10 +31,10 @@ def cpu_info():
     ls_cpu = lscpu()
 
     return {
-        'cpus': ls_cpu['cpus'],
-        'threads_per_core': ls_cpu['threads_per_core'],
-        'cores_per_socket': ls_cpu['cores_per_socket'],
-        'sockets_per_board': ls_cpu['sockets'],
+        "cpus": ls_cpu["cpus"],
+        "threads_per_core": ls_cpu["threads_per_core"],
+        "cores_per_socket": ls_cpu["cores_per_socket"],
+        "sockets_per_board": ls_cpu["sockets"],
     }
 
 
@@ -42,8 +43,7 @@ def free_m():
     real_mem = ""
     try:
         real_mem = subprocess.check_output(
-            "free -m | grep -oP '\\d+' | head -n 1",
-            shell=True
+            "free -m | grep -oP '\\d+' | head -n 1", shell=True
         )
     except subprocess.CalledProcessError as e:
         print(e)
@@ -60,8 +60,10 @@ def lspci_nvidia():
             subprocess.check_output(
                 "lspci | grep -i nvidia | awk '{print $1}' "
                 "| cut -d : -f 1 | sort -u | wc -l",
-                shell=True
-            ).decode().strip()
+                shell=True,
+            )
+            .decode()
+            .strip()
         )
     except subprocess.CalledProcessError as e:
         print(e)
@@ -77,31 +79,29 @@ def lspci_nvidia():
 def get_inventory(node_name, node_addr):
     """Assemble and return the node info."""
     inventory = {
-        'node_name': node_name,
-        'node_addr': node_addr,
-        'state': "UNKNOWN",
-        'real_memory': free_m(),
+        "node_name": node_name,
+        "node_addr": node_addr,
+        "state": "UNKNOWN",
+        "real_memory": free_m(),
         **cpu_info(),
     }
 
     gpus = lspci_nvidia()
-    if (gpus > 0):
-        inventory['gres'] = gpus
+    if gpus > 0:
+        inventory["gres"] = gpus
     return inventory
 
 
 def _related_units(relid):
     """List of related units."""
-    units_cmd_line = ['relation-list', '--format=json', '-r', relid]
-    return json.loads(
-        subprocess.check_output(units_cmd_line).decode('UTF-8')) or []
+    units_cmd_line = ["relation-list", "--format=json", "-r", relid]
+    return json.loads(subprocess.check_output(units_cmd_line).decode("UTF-8")) or []
 
 
 def _relation_ids(reltype):
     """List of relation_ids."""
-    relid_cmd_line = ['relation-ids', '--format=json', reltype]
-    return json.loads(
-        subprocess.check_output(relid_cmd_line).decode('UTF-8')) or []
+    relid_cmd_line = ["relation-ids", "--format=json", reltype]
+    return json.loads(subprocess.check_output(relid_cmd_line).decode("UTF-8")) or []
 
 
 def get_active_units(relation_name):
@@ -119,7 +119,6 @@ def random_string(length=10):
     for i in range(length):
         random_integer = random.randint(97, 97 + 26 - 1)
         flip_bit = random.randint(0, 1)
-        random_integer = \
-            random_integer - 32 if flip_bit == 1 else random_integer
-        random_str += (chr(random_integer))
+        random_integer = random_integer - 32 if flip_bit == 1 else random_integer
+        random_str += chr(random_integer)
     return random_str

--- a/charm-slurmd/src/utils.py
+++ b/charm-slurmd/src/utils.py
@@ -113,7 +113,7 @@ def get_active_units(relation_name):
     return active_units
 
 
-def random_string(length=10):
+def random_string(length=4):
     """Generate a random string."""
     random_str = ""
     for i in range(length):

--- a/charm-slurmdbd/config.yaml
+++ b/charm-slurmdbd/config.yaml
@@ -1,4 +1,9 @@
 options:
+  snapstore-channel:
+    type: string
+    default: "--stable"
+    description:
+      'Snap store channel to install the slurm snap from.'
   slurmdbd_debug:
     type: string
     default: info

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v15
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -50,7 +50,7 @@ class SlurmdbdCharm(CharmBase):
             self.framework.observe(event, handler)
 
     def _on_install(self, event):
-        self._slurm_manager.install()
+        self._slurm_manager.install(self.config["snapstore-channel"])
         self._stored.slurm_installed = True
         self.unit.status = ActiveStatus("slurm snap successfully installed")
 

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -10,10 +10,7 @@ from nrpe_external_master import Nrpe
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-)
+from ops.model import ActiveStatus, BlockedStatus
 from slurm_ops_manager import SlurmManager
 
 logger = logging.getLogger()
@@ -43,20 +40,11 @@ class SlurmdbdCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
-
             self.on.config_changed: self._write_config_and_restart_slurmdbd,
-
-            self._db.on.database_available:
-            self._write_config_and_restart_slurmdbd,
-
-            self._slurmdbd_peer.on.slurmdbd_peer_available:
-            self._write_config_and_restart_slurmdbd,
-
-            self._slurmdbd.on.slurmdbd_available:
-            self._write_config_and_restart_slurmdbd,
-
-            self._slurmdbd.on.slurmdbd_unavailable:
-            self._on_slurmdbd_unavailable,
+            self._db.on.database_available: self._write_config_and_restart_slurmdbd,
+            self._slurmdbd_peer.on.slurmdbd_peer_available: self._write_config_and_restart_slurmdbd,
+            self._slurmdbd.on.slurmdbd_available: self._write_config_and_restart_slurmdbd,
+            self._slurmdbd.on.slurmdbd_unavailable: self._on_slurmdbd_unavailable,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -92,13 +80,9 @@ class SlurmdbdCharm(CharmBase):
 
         if not all(deps):
             if not db_info:
-                self.unit.status = BlockedStatus(
-                    "Need relation to MySQL."
-                )
+                self.unit.status = BlockedStatus("Need relation to MySQL.")
             elif not munge_key:
-                self.unit.status = BlockedStatus(
-                    "Need relation to slurm-configurator."
-                )
+                self.unit.status = BlockedStatus("Need relation to slurm-configurator.")
             return False
         return True
 
@@ -114,7 +98,7 @@ class SlurmdbdCharm(CharmBase):
         slurmdbd_info = self._slurmdbd_peer.get_slurmdbd_info()
 
         slurmdbd_config = {
-            'munge_key': self._stored.munge_key,
+            "munge_key": self._stored.munge_key,
             **self.model.config,
             **slurmdbd_info,
             **db_info,
@@ -162,8 +146,8 @@ class SlurmdbdCharm(CharmBase):
                     # matters in the context of making sure the application
                     # relation data actually changes so that relation-changed
                     # event is observed on the other side.
-                    'slurmdbd_info_id': str(uuid.uuid4()),
-                    **slurmdbd_info
+                    "slurmdbd_info_id": str(uuid.uuid4()),
+                    **slurmdbd_info,
                 }
             )
         self.unit.status = ActiveStatus("Slurmdbd Available")

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 """Slurmdbd Operator Charm."""
 import logging
-import uuid
 
 from interface_mysql import MySQLClient
 from interface_slurmdbd import Slurmdbd

--- a/charm-slurmdbd/src/interface_mysql.py
+++ b/charm-slurmdbd/src/interface_mysql.py
@@ -2,13 +2,7 @@
 """MySqlRequires."""
 import logging
 
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 logger = logging.getLogger()
 
@@ -37,7 +31,7 @@ class MySQLClient(Object):
         # self.on_relation_changed() to handle the event.
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
     def _on_relation_changed(self, event):
@@ -46,19 +40,21 @@ class MySQLClient(Object):
             event.defer()
             return
 
-        user = event_unit_data.get('user')
-        password = event_unit_data.get('password')
-        host = event_unit_data.get('host')
-        database = event_unit_data.get('database')
+        user = event_unit_data.get("user")
+        password = event_unit_data.get("password")
+        host = event_unit_data.get("host")
+        database = event_unit_data.get("database")
 
-        if (user and password and host and database):
-            self._charm.set_db_info({
-                'db_username': user,
-                'db_password': password,
-                'db_hostname': host,
-                'db_port': "3306",
-                'db_name': database,
-            })
+        if user and password and host and database:
+            self._charm.set_db_info(
+                {
+                    "db_username": user,
+                    "db_password": password,
+                    "db_hostname": host,
+                    "db_port": "3306",
+                    "db_name": database,
+                }
+            )
             self.on.database_available.emit()
         else:
             logger.info("DB INFO NOT AVAILABLE")

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -43,8 +43,8 @@ class Slurmdbd(Object):
         self._relation_name = relation_name
 
         self.framework.observe(
-            self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed,
+            self._charm.on[self._relation_name].relation_joined,
+            self._on_relation_joined,
         )
 
         self.framework.observe(
@@ -52,23 +52,31 @@ class Slurmdbd(Object):
             self._on_relation_broken,
         )
 
-    def _on_relation_changed(self, event):
-        app_relation_data = event.relation.data.get(event.app)
-        # Check for the existence of the app in the relation data
-        # defer if not exists.
-        if not app_relation_data:
+    def _on_relation_joined(self, event):
+        """Handle the relation-joined event.
+
+        Get the munge_key from slurm-configurator and save it to the
+        charm stored state.
+        """
+        # Since we are in relation-joined (with the app on the other side)
+        # we can almost guarantee that the app object will exist in
+        # the event, but check for it just in case.
+        event_app_data = event.relation.data.get(event.app)
+        if not event_app_data:
             event.defer()
             return
 
-        munge_key = app_relation_data.get("munge_key")
-        # Check for the existence of the munge key in the relation data
-        # defer if not exists.
+        # slurm-configurator sets the munge_key on the relation-created event
+        # which happens before relation-joined. We can almost guarantee that
+        # the munge key will exist at this point, but check for it just incase.
+        munge_key = event_app_data.get("munge_key")
         if not munge_key:
             event.defer()
             return
 
+        # Store the munge_key in the charm's state
         self._charm.set_munge_key(munge_key)
-        self.on.slurmdbd_available.emit()
+        self.on.munge_key_available.emit()
 
     def _on_relation_broken(self, event):
         self.set_slurmdbd_info_on_app_relation_data("")

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -3,15 +3,7 @@
 import json
 import logging
 
-
-from ops.framework import (
-    EventBase,
-    EventSource,
-    Object,
-    ObjectEvents,
-    StoredState,
-)
-
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 
 logger = logging.getLogger()
 
@@ -52,12 +44,12 @@ class Slurmdbd(Object):
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
-            self._on_relation_changed
+            self._on_relation_changed,
         )
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken,
-            self._on_relation_broken
+            self._on_relation_broken,
         )
 
     def _on_relation_changed(self, event):
@@ -68,7 +60,7 @@ class Slurmdbd(Object):
             event.defer()
             return
 
-        munge_key = app_relation_data.get('munge_key')
+        munge_key = app_relation_data.get("munge_key")
         # Check for the existence of the munge key in the relation data
         # defer if not exists.
         if not munge_key:
@@ -84,12 +76,12 @@ class Slurmdbd(Object):
 
     def set_slurmdbd_info_on_app_relation_data(self, slurmdbd_info):
         """Set slurmdbd_info."""
-        relations = self.framework.model.relations['slurmdbd']
+        relations = self.framework.model.relations["slurmdbd"]
         # Iterate over each of the relations setting the relation data.
         for relation in relations:
             if slurmdbd_info != "":
-                relation.data[self.model.app]['slurmdbd_info'] = json.dumps(
+                relation.data[self.model.app]["slurmdbd_info"] = json.dumps(
                     slurmdbd_info
                 )
             else:
-                relation.data[self.model.app]['slurmdbd_info'] = ""
+                relation.data[self.model.app]["slurmdbd_info"] = ""

--- a/charm-slurmdbd/src/interface_slurmdbd_peer.py
+++ b/charm-slurmdbd/src/interface_slurmdbd_peer.py
@@ -54,7 +54,7 @@ class SlurmdbdPeer(Object):
         unit_relation_data["hostname"] = self._charm.get_hostname()
         unit_relation_data["port"] = self._charm.get_port()
 
-        # Call _on_relation_changed to assemble the slurmctld_info and
+        # Call _on_relation_changed to assemble the slurmdbd_info and
         # emit the slurmdbd_peer_available event.
         self._on_relation_changed(event)
 

--- a/charm-slurmrestd/config.yaml
+++ b/charm-slurmrestd/config.yaml
@@ -1,0 +1,6 @@
+options:
+  snapstore-channel:
+    type: string
+    default: "--stable"
+    description:
+      'Snap store channel to install the slurm snap from.'

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.8
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless_v15

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.8

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@configless

--- a/charm-slurmrestd/src/charm.py
+++ b/charm-slurmrestd/src/charm.py
@@ -71,7 +71,7 @@ class SlurmLoginCharm(CharmBase):
             return
         elif not (slurm_installed and slurm_config):
             self.unit.status = WaitingStatus(
-                "Waiting on: configurator"
+                "Waiting on: configuration"
             )
             event.defer()
             return

--- a/charm-slurmrestd/src/charm.py
+++ b/charm-slurmrestd/src/charm.py
@@ -48,7 +48,7 @@ class SlurmLoginCharm(CharmBase):
             self.framework.observe(event, handler)
 
     def _on_install(self, event):
-        self.slurm_manager.install()
+        self.slurm_manager.install(self.config["snapstore-channel"])
         self.unit.status = ActiveStatus("slurm installed")
         self._stored.slurm_installed = True
 

--- a/charm-slurmrestd/src/slurmrestd_requires.py
+++ b/charm-slurmrestd/src/slurmrestd_requires.py
@@ -38,17 +38,16 @@ class SlurmrestdRequires(Object):
     def __init__(self, charm, relation_name):
         """Set the provides initial data."""
         super().__init__(charm, relation_name)
-        self.charm = charm
 
+        self._charm = charm
         self._relation_name = relation_name
 
-
         self.framework.observe(
-            charm.on[relation_name].relation_changed,
+            self._charm.on[relation_name].relation_changed,
             self._on_relation_changed
         )
         self.framework.observe(
-            charm.on[relation_name].relation_broken,
+            self._charm.on[relation_name].relation_broken,
             self._on_relation_broken
         )
 
@@ -64,11 +63,11 @@ class SlurmrestdRequires(Object):
             event.defer()
             return
 
-        self.charm.set_config_available(True)
+        self._charm.set_config_available(True)
         self.on.config_available.emit()
 
     def _on_relation_broken(self, event):
-        self.charm.set_config_available(False)
+        self._charm.set_config_available(False)
         self.on.config_available.emit()
 
     def get_slurm_config(self):

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ exclude =
     __pycache__,
     .tox,
     mod,
-max-line-length = 79
+max-line-length = 88
 max-complexity = 10
 ignore = E203, E501, W503, I201, I100
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ exclude =
     mod,
 max-line-length = 79
 max-complexity = 10
-import-order-style = edited
+ignore = E203, E501, W503, I201, I100
 
 [isort]
 lines_after_imports = 2

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = functest-run-suite {posargs}
 deps = -r{toxinidir}/tests/functional/requirements.txt
 
 [testenv:lint]
-commands = flake8 {posargs} charm-slurmd/src/ charm-slurmdbd/src/ charm-slurmctld/src/ charm-slurm-configurator/src/
+commands = flake8 --ignore=C901 {posargs} charm-slurmd/src/ charm-slurmdbd/src/ charm-slurmctld/src/ charm-slurm-configurator/src/
 deps =
     flake8
     flake8-docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,7 @@ max-complexity = 10
 import-order-style = edited
 
 [isort]
-force_to_top=setuppath
+lines_after_imports = 2
+# ignore from..import vs import while sorting a section
+force_sort_within_sections = 1
+profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = functest-run-suite {posargs}
 deps = -r{toxinidir}/tests/functional/requirements.txt
 
 [testenv:lint]
-commands = flake8 --ignore=C901 {posargs} charm-slurmd/src/ charm-slurmdbd/src/ charm-slurmctld/src/ charm-slurm-configurator/src/
+commands = flake8 {posargs} charm-slurmd/src/ charm-slurmdbd/src/ charm-slurmctld/src/ charm-slurm-configurator/src/
 deps =
     flake8
     flake8-docstrings


### PR DESCRIPTION
This PR introduces code that ensures that the correct configuration is distributed across the cluster following the addition/removal of nodes and that running jobs are uninterrupted when nodes are added or removed.

Utility actions added:
* `slurm-configurator:restart-slurmctld`
The `restart-slurmctld` action allows administrators to restart the slurmctld process via charm action.
* `slurm-configurator:restart-slurmd`
The `restart-slurmd` action allows administrators to restart slurmd processes via charm action.
*  `slurm-configurator:get-slurm-conf`
The `get-slurm-conf` action returns the runtime slurm.conf via action output.
*  `slurm-configurator:set-slurm-confg`
The `set-slurm-config` action allows slurm administrators to set an override slurm configuration that supersedes the configuration generated by juju. 
