### PR TITLE
slurmdbd: remove snap-store-channel config

### DIFF
--- a/charm-slurmdbd/config.yaml
+++ b/charm-slurmdbd/config.yaml
@@ -12,10 +12,6 @@ options:
       is info. If the slurmdbd daemon is initiated with -v or --verbose
       options, that debug level will be preserve or restored upon
       reconfiguration."
-  snap-store-channel:
-    type: string
-    description: snap store channel to install slurm snap from
-    default: "stable"
   nagios_context:
     default: "juju"
     type: string


### PR DESCRIPTION
The current configuration for the snap channel is `snapstore-channel`.