### PR TITLE
177305011 support jwt auth

### DIFF
--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -193,7 +193,7 @@ jobs:
           juju deploy -m $model \
               ./../slurm-bundles/slurm-core/bundle.yaml \
               --overlay ./../slurm-bundles/slurm-core/clouds/aws.yaml \
-              --overlay ./../slurm-bundles/slurm-core/options/beta-snap.yaml \
+              --overlay ./../slurm-bundles/slurm-core/options/edge-snap.yaml \
               --overlay ./../slurm-bundles/slurm-core/series/${{ matrix.series }}.yaml
 
       - name: "Wait for deployments to settle"

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.0.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0

--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.1

--- a/charm-slurm-configurator/src/charm.py
+++ b/charm-slurm-configurator/src/charm.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-"""SlurmctldCharm."""
+#!/usr/bin/env python3
+"""SlurmConfiguratorCharm."""
 import copy
 import logging
 
@@ -33,6 +33,7 @@ class SlurmConfiguratorCharm(CharmBase):
 
         self._stored.set_default(
             munge_key=str(),
+            jwt_rsa=str(),
             override_slurm_conf=None,
             slurm_installed=False,
             slurmd_restarted=False,
@@ -108,7 +109,15 @@ class SlurmConfiguratorCharm(CharmBase):
     def _on_install(self, event):
         """Install the slurm snap and capture the munge key."""
         self._slurm_manager.install(self.config["snapstore-channel"])
-        self._stored.munge_key = self._slurm_manager.get_munge_key()
+
+        # Store the munge_key and jwt_rsa key in the stored state.
+        #
+        # NOTE: Use leadership settings instead of stored state when
+        # leadership settings support becomes available in the framework.
+        if self._is_leader():
+            self._stored.jwt_rsa = self._slurm_manager.generate_jwt_rsa()
+            self._stored.munge_key = self._slurm_manager.get_munge_key()
+
         self._stored.slurm_installed = True
         self.unit.status = ActiveStatus("slurm installed")
 
@@ -352,6 +361,10 @@ class SlurmConfiguratorCharm(CharmBase):
     def get_munge_key(self):
         """Return the slurmdbd_info from stored state."""
         return self._stored.munge_key
+
+    def get_jwt_rsa(self):
+        """Return the jwt rsa key."""
+        return self._stored.jwt_rsa
 
     def is_slurm_installed(self):
         """Return true/false based on whether or not slurm is installed."""

--- a/charm-slurm-configurator/src/interface_slurmctld.py
+++ b/charm-slurm-configurator/src/interface_slurmctld.py
@@ -69,6 +69,7 @@ class Slurmctld(Object):
         # data on the relation to be retrieved on the other side by slurmctld.
         app_relation_data = event.relation.data[self.model.app]
         app_relation_data["munge_key"] = self._charm.get_munge_key()
+        app_relation_data["jwt_rsa"] = self._charm.get_jwt_rsa()
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)

--- a/charm-slurm-configurator/src/interface_slurmdbd.py
+++ b/charm-slurm-configurator/src/interface_slurmdbd.py
@@ -57,15 +57,23 @@ class Slurmdbd(Object):
         )
 
     def _on_relation_created(self, event):
+        """Perform relation-created event operations."""
+
         # Check that slurm has been installed so that we know the munge key is
         # available. Defer if slurm has not been installed yet.
         if not self._charm.is_slurm_installed():
             event.defer()
             return
-        # Get the munge_key from the slurm_ops_manager and set it to the app
-        # data on the relation to be retrieved on the other side by slurmdbd.
+
+        # Get the munge_key and sett it to the application relation data,
+        # to be retrieved on the other side by slurmdbd.
         munge_key = self._charm.get_munge_key()
         event.relation.data[self.model.app]["munge_key"] = munge_key
+
+        # Get the jwt_rsa key from the slurm_ops_manager and set it to the app
+        # data on the relation to be retrieved on the other side by slurmdbd.
+        jwt_rsa = self._charm.get_jwt_rsa()
+        event.relation.data[self.model.app]["jwt_rsa"] = jwt_rsa
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)

--- a/charm-slurm-configurator/src/interface_slurmdbd.py
+++ b/charm-slurm-configurator/src/interface_slurmdbd.py
@@ -58,7 +58,6 @@ class Slurmdbd(Object):
 
     def _on_relation_created(self, event):
         """Perform relation-created event operations."""
-
         # Check that slurm has been installed so that we know the munge key is
         # available. Defer if slurm has not been installed yet.
         if not self._charm.is_slurm_installed():

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.0.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.1
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -24,7 +24,7 @@ class SlurmctldCharm(CharmBase):
         super().__init__(*args)
 
         self._stored.set_default(
-            munge_key_available=False,
+            slurm_configurator_available=False,
             slurmctld_controller_type=str(),
         )
 
@@ -37,11 +37,15 @@ class SlurmctldCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
-            self._slurmctld.on.slurm_config_available: self._on_check_status_and_write_config,
-            self._slurmctld.on.scontrol_reconfigure: self._on_scontrol_reconfigure,
+            self._slurmctld.on.slurm_config_available:
+            self._on_check_status_and_write_config,
+            self._slurmctld.on.scontrol_reconfigure:
+            self._on_scontrol_reconfigure,
             self._slurmctld.on.restart_slurmctld: self._on_restart_slurmctld,
-            self._slurmctld.on.munge_key_available: self._on_write_munge_key,
-            self._slurmctld_peer.on.slurmctld_peer_available: self._on_slurmctld_peer_available,
+            self._slurmctld.on.slurm_configurator_available:
+            self._on_provision_keys,
+            self._slurmctld_peer.on.slurmctld_peer_available:
+            self._on_slurmctld_peer_available,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -56,14 +60,21 @@ class SlurmctldCharm(CharmBase):
         snapstore_channel = self.config["snapstore-channel"]
         self._slurm_manager.upgrade(slurm_config, snapstore_channel)
 
-    def _on_write_munge_key(self, event):
+    def _on_provision_keys(self, event):
         if not self._stored.slurm_installed:
             event.defer()
             return
+
+        # Retrieve the munge_key and jwt_rsa from the slurm-configurator
         munge_key = self._slurmctld.get_stored_munge_key()
+        jwt_rsa = self._slurmctld.get_stored_jwt_rsa()
+
+        # Write the keys to their respective locations in the filesystem
         self._slurm_manager.configure_munge_key(munge_key)
+        self._slurm_manager.configure_jwt_rsa(jwt_rsa)
+
         self._slurm_manager.restart_munged()
-        self._stored.munge_key_available = True
+        self._stored.slurm_configurator_available = True
 
     def _on_slurmctld_peer_available(self, event):
         if self.framework.model.unit.is_leader():
@@ -93,11 +104,18 @@ class SlurmctldCharm(CharmBase):
         self._slurm_manager.slurm_cmd("scontrol", "reconfigure")
 
     def _check_status(self):
-        munge_key_available = self._stored.munge_key_available
+        slurm_configurator_available = \
+            self._stored.slurm_configurator_available
         slurm_installed = self._stored.slurm_installed
         slurm_config = self._slurmctld.get_stored_slurm_config()
 
         slurmctld_joined = self._slurmctld.is_joined
+
+        all_components = [
+            slurm_configurator_available,
+            slurm_installed,
+            slurm_config,
+        ]
 
         if not slurmctld_joined:
             self.unit.status = BlockedStatus(
@@ -105,7 +123,7 @@ class SlurmctldCharm(CharmBase):
             )
             return None
 
-        elif not (munge_key_available and slurm_installed and slurm_config):
+        elif not all(all_components):
             self.unit.status = WaitingStatus(
                 "Waiting on: configuration"
             )

--- a/charm-slurmctld/src/interface_slurmctld.py
+++ b/charm-slurmctld/src/interface_slurmctld.py
@@ -24,24 +24,28 @@ class ScontrolReconfigureEvent(EventBase):
 
 
 class SlurmConfiguratorAvailableEvent(EventBase):
-    """Emitted when slurm-config is available."""
+    """Emitted when slurm configurator relation has joined."""
 
 
 class SlurmConfiguratorUnAvailableEvent(EventBase):
     """Emitted when a slurmctld unit joins the relation."""
 
 
+class SlurmConfigAvailableEvent(EventBase):
+    """Emitted when slurm-config is available."""
+
+
 class SlurmctldEvents(ObjectEvents):
     """Slurmctld emitted events."""
 
     slurm_config_available = EventSource(
+        SlurmConfigAvailableEvent
+    )
+    slurm_configurator_available = EventSource(
         SlurmConfiguratorAvailableEvent
     )
     slurm_configurator_unavailable = EventSource(
         SlurmConfiguratorUnAvailableEvent
-    )
-    munge_key_available = EventSource(
-        MungeKeyAvailableEvent
     )
     restart_slurmctld = EventSource(
         RestartSlurmctldEvent
@@ -66,6 +70,7 @@ class Slurmctld(Object):
         self._stored.set_default(
             slurm_config=dict(),
             munge_key=str(),
+            jwt_rsa=str(),
             restart_slurmctld_uuid=str(),
             scontrol_reconfigure_uuid=str(),
         )
@@ -109,9 +114,18 @@ class Slurmctld(Object):
             event.defer()
             return
 
-        # Store the munge_key in the charm's state
+        # slurm-configurator sets the jwt_rsa on the relation-created event
+        # which happens before relation-joined. We can almost guarantee that
+        # the munge key will exist at this point, but check for it just incase.
+        jwt_rsa = event_app_data.get("jwt_rsa")
+        if not jwt_rsa:
+            event.defer()
+            return
+
+        # Store the jwt_rsa and munge_key in the charm's state
         self._store_munge_key(munge_key)
-        self.on.munge_key_available.emit()
+        self._store_jwt_rsa(jwt_rsa)
+        self.on.slurm_configurator_available.emit()
 
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
@@ -194,6 +208,13 @@ class Slurmctld(Object):
     def get_stored_munge_key(self):
         """Retrieve the munge_key from stored state."""
         return self._stored.munge_key
+
+    def _store_jwt_rsa(self, jwt_rsa):
+        self._stored.jwt_rsa = jwt_rsa
+
+    def get_stored_jwt_rsa(self):
+        """Retrieve the jwt_rsa from stored state."""
+        return self._stored.jwt_rsa
 
     def _store_slurm_config(self, slurm_config):
         self._stored.slurm_config = slurm_config

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.0.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.1
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/dispatch
+++ b/charm-slurmdbd/dispatch
@@ -21,12 +21,14 @@ if ! [[ -f '.installed' ]]; then
 	if [[ $major == "7" ]]; then
 	    yum -y install epel-release
             yum -y install python3
+            yum -y install pciutils
 	    yum -y --enablerepo=epel-testing install snapd
 	elif [[ $major == "8" ]]; then
 	    dnf -y install epel-release
 	    dnf -y install python3
             dnf -y upgrade
 	    dnf -y install snapd
+            dnf -y install pciutils
         else
 	    echo "Running unsuppored version of centos: $major"
 	    exit -1

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.0.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.1
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -81,8 +81,7 @@ class SlurmdbdCharm(CharmBase):
         self._stored.slurm_configurator_available = True
 
     def _on_slurm_configurator_unavailable(self, event):
-        """Reset state and charm status when slurm-configurator relation broken.
-        """
+        """Reset state and charm status when slurm-configurator broken."""
         self._stored.slurm_configurator_available = False
         self._check_status()
 

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -15,8 +15,8 @@ class SlurmdbdAvailableEvent(EventBase):
     """Emitted when slurmdbd is available."""
 
 
-class SlurmdbdUnAvailableEvent(EventBase):
-    """Emitted when slurmdbd is unavailable."""
+class SlurmConfiguratorUnAvailableEvent(EventBase):
+    """Emitted when slurm-configurator is unavailable."""
 
 
 class SlurmConfiguratorAvailableEvent(EventBase):
@@ -27,8 +27,10 @@ class SlurmdbdEvents(ObjectEvents):
     """Slurmdbd relation events."""
 
     slurm_configurator_available = EventSource(SlurmConfiguratorAvailableEvent)
+    slurm_configurator_unavailable = EventSource(
+        SlurmConfiguratorAvailableEvent
+    )
     slurmdbd_available = EventSource(SlurmdbdAvailableEvent)
-    slurmdbd_unavailable = EventSource(SlurmdbdUnAvailableEvent)
 
 
 class Slurmdbd(Object):
@@ -99,7 +101,7 @@ class Slurmdbd(Object):
         """Clear the application relation data and emit the unavailable event.
         """
         self.set_slurmdbd_info_on_app_relation_data("")
-        self.on.slurmdbd_unavailable.emit()
+        self.on.slurm_configurator_unavailable.emit()
 
     def set_slurmdbd_info_on_app_relation_data(self, slurmdbd_info):
         """Send slurmdbd_info to slurm-configurator."""
@@ -125,6 +127,6 @@ class Slurmdbd(Object):
         """Store the jwt_rsa in the interface stored state."""
         self._stored.jwt_rsa = jwt_rsa
 
-    def get_stored_jwt_rsa(self):
+    def get_jwt_rsa(self):
         """Retrieve the jwt_rsa from stored state."""
         return self._stored.jwt_rsa

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -98,8 +98,7 @@ class Slurmdbd(Object):
         self.on.slurm_configurator_available.emit()
 
     def _on_relation_broken(self, event):
-        """Clear the application relation data and emit the unavailable event.
-        """
+        """Clear the application relation data and emit the event."""
         self.set_slurmdbd_info_on_app_relation_data("")
         self.on.slurm_configurator_unavailable.emit()
 

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -19,14 +19,14 @@ class SlurmdbdUnAvailableEvent(EventBase):
     """Emitted when slurmdbd is unavailable."""
 
 
-class MungeKeyAvailableEvent(EventBase):
-    """Emitted when the munge key becomes available."""
+class SlurmConfiguratorAvailableEvent(EventBase):
+    """Emitted when slurm-configurator joins the relation."""
 
 
 class SlurmdbdEvents(ObjectEvents):
     """Slurmdbd relation events."""
 
-    munge_key_available = EventSource(MungeKeyAvailableEvent)
+    slurm_configurator_available = EventSource(SlurmConfiguratorAvailableEvent)
     slurmdbd_available = EventSource(SlurmdbdAvailableEvent)
     slurmdbd_unavailable = EventSource(SlurmdbdUnAvailableEvent)
 
@@ -45,7 +45,8 @@ class Slurmdbd(Object):
         self._relation_name = relation_name
 
         self._stored.set_default(
-            munge_key=None,
+            munge_key=str(),
+            jwt_key=str(),
         )
 
         self.framework.observe(
@@ -80,17 +81,28 @@ class Slurmdbd(Object):
             event.defer()
             return
 
-        # Store the munge_key in the interface's stored state object and emit
-        # munge_key_available.
+        # slurm-configurator sets the jwt_rsa on the relation-created event
+        # which happens before relation-joined. We can almost guarantee that
+        # the munge key will exist at this point, but check for it just incase.
+        jwt_rsa = event_app_data.get("jwt_rsa")
+        if not jwt_rsa:
+            event.defer()
+            return
+
+        # Store the munge_key and jwt_rsa in the interface's stored state
+        # object and emit the slurm_configurator_available event.
         self._store_munge_key(munge_key)
-        self.on.munge_key_available.emit()
+        self._store_jwt_rsa(jwt_rsa)
+        self.on.slurm_configurator_available.emit()
 
     def _on_relation_broken(self, event):
+        """Clear the application relation data and emit the unavailable event.
+        """
         self.set_slurmdbd_info_on_app_relation_data("")
         self.on.slurmdbd_unavailable.emit()
 
     def set_slurmdbd_info_on_app_relation_data(self, slurmdbd_info):
-        """Set slurmdbd_info."""
+        """Send slurmdbd_info to slurm-configurator."""
         relations = self.framework.model.relations["slurmdbd"]
         # Iterate over each of the relations setting the relation data.
         for relation in relations:
@@ -108,3 +120,11 @@ class Slurmdbd(Object):
     def get_munge_key(self):
         """Retrieve the munge key from the stored state."""
         return self._stored.munge_key
+
+    def _store_jwt_rsa(self, jwt_rsa):
+        """Store the jwt_rsa in the interface stored state."""
+        self._stored.jwt_rsa = jwt_rsa
+
+    def get_stored_jwt_rsa(self):
+        """Retrieve the jwt_rsa from stored state."""
+        return self._stored.jwt_rsa

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.0.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@177304892_support_jwt_0
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.1.1

--- a/local-snap.yaml
+++ b/local-snap.yaml
@@ -1,0 +1,17 @@
+applications:
+  slurmd:
+    resources:
+      slurm: ./slurm.resource
+  slurmctld:
+    resources:
+      slurm: ./slurm.resource
+  slurmdbd:
+    resources:
+      slurm: ./slurm.resource
+  slurm-configurator:
+    resources:
+      slurm: ./slurm.resource
+  slurmrestd:
+    resources:
+      slurm: ./slurm.resource
+


### PR DESCRIPTION
Facilitate jwt auth ops in the slurm charms.

* workflow to generate a hs256 key in slurm-configurator and send the key to slurmctld and slurmdbd via relation data
* add helpers to get and set the key to the charm state in the 3 charms
* drive by fix to install lspci in the install hook/dispatch file

closes #61