### PR TITLE
Update actions

### DIFF
--- a/charm-slurm-configurator/requirements.txt
+++ b/charm-slurm-configurator/requirements.txt
@@ -1,3 +1,3 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.2

--- a/charm-slurmctld/actions.yaml
+++ b/charm-slurmctld/actions.yaml
@@ -1,0 +1,29 @@
+drain:
+  description: >
+    Drain specified nodes.
+
+    Example usage: juju run-action slurmctld/leader drain nodename=node-[1,2] reason="Updating kernel"
+  params:
+    nodename:
+      type: string
+      description: The nodes to drain, Using the Slurm format, e.g. node-[1,2].
+    reason:
+      type: string
+      description: Reason to drain the nodes.
+  required:
+    - nodename
+    - reason
+resume:
+  description: >
+    Resume specified nodes.
+
+    Note: newly added nodes will remain in the "down" state until configured,
+    with the node-configured action.
+
+    Example usage: juju run-action slurmctld/leader resume nodename=node-[1,2]
+  params:
+    nodename:
+      type: string
+      description: The nodes to resume, Using the Slurm format, e.g. node-[1,2].
+  required:
+    - nodename

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -1,15 +1,3 @@
-set-node-state:
-  description: >
-    Set specific node:states mappings for nodes in this partition. Acceptable
-    node state values are; DOWN, DRAIN, FAIL, or FAILING. Ex.
-    n-c100=DOWN,n-c101=DOWN
-  params:
-    node-state:
-      type: string
-      description: The node name and state.
-  required:
-    - node-state
-  type: object
 node-configured:
   description: Remove a nove from DownNodes when the reason is "New node".
 get-node-inventory:

--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -21,6 +21,9 @@ show-current-config:
     This action is best visualized with:
     $ juju show-action-output 206 --format=json | jq .results.slurm.conf | xargs -I % -0 python3 -c 'print(%)'
 
+show-nhc-config:
+  description: Display the currently used nhc.conf
+
 get-infiniband-repo:
   description: Display the currently configured repository for Infiniband drivers.
 set-infiniband-repo:

--- a/charm-slurmd/config.yaml
+++ b/charm-slurmd/config.yaml
@@ -42,3 +42,11 @@ options:
     description: |
       Custom extra configuration to use for Node Health Check.
       These lines are appended to a basic nhc.conf provided by the charm.
+  health-check-interval:
+    default: 600
+    type: int
+    description: Interval in seconds between executions of the Health Check.
+  health-check-state:
+    default: "ANY,CYCLE"
+    type: string
+    description: Only run the Health Check on nodes in this state.

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -193,6 +193,7 @@ class SlurmdCharm(CharmBase):
         logger.debug("#### Installing Infiniband")
         self._slurm_manager.infiniband.install()
         event.set_results({'installation': 'Successfull. Please reboot node.'})
+        self.unit.status = BlockedStatus("Need reboot for Infiniband")
 
     def uninstall_infiniband(self, event):
         """Install infiniband."""

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -61,6 +61,7 @@ class SlurmdCharm(CharmBase):
             self.on.get_node_inventory_action:
             self._on_get_node_inventory_action,
             self.on.show_current_config_action: self._on_show_current_config,
+            self.on.show_nhc_config_action: self._on_show_nhc_config,
             # infiniband actions
             self.on.get_infiniband_repo_action: self.get_infiniband_repo,
             self.on.set_infiniband_repo_action: self.set_infiniband_repo,
@@ -225,6 +226,11 @@ class SlurmdCharm(CharmBase):
         """Show current slurm.conf."""
         slurm_conf = self._slurm_manager.get_slurm_conf()
         event.set_results({"slurm.conf": slurm_conf})
+
+    def _on_show_nhc_config(self, event):
+        """Show current nhc.conf."""
+        nhc_conf = self._slurm_manager.get_nhc_config()
+        event.set_results({"nhc.conf": nhc_conf})
 
     def _on_set_partition_info_on_app_relation_data(self, event):
         """Set the slurm partition info on the application relation data."""

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.5.2

--- a/tests/20-nhc-config.bats
+++ b/tests/20-nhc-config.bats
@@ -19,3 +19,15 @@ myjuju () {
 	run juju run --unit slurmd/leader "tail -n 4 $nhc_conf"
 	assert_output --partial "# new config"
 }
+
+@test "Assert we can change the slurm settings for NHC - interval" {
+	juju config slurmd health-check-interval=3
+	run juju run-action slurmd/leader show-current-config --wait
+	assert_output --partial "HealthCheckInterval=3"
+}
+
+@test "Assert we can change the slurm settings for NHC - state" {
+	juju config slurmd health-check-state="CYCLE,ANY"
+	run juju run-action slurmd/leader show-current-config --wait
+	assert_output --partial "HealthCheckNodeState=CYCLE,ANY"
+}


### PR DESCRIPTION
- set the slurmd status to blocked after installing ib drivers
- add slurmd action to get nhc.conf
- add slurmd configs to fine tune HealthCheckInterval and HealthCheckState
- add drain/resume actions in slurmctld to drain/resume nodes
- remove slurmd's set-node-state action in favor of drain/resume

depends on https://github.com/omnivector-solutions/slurm-ops-manager/pull/49