### PR TITLE
slurmd: change action to receive base64 encoded repo

### DIFF
--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -19,11 +19,13 @@ set-infiniband-repo:
   params:
     repo:
       type: string
-      description: String that holds all information about the repository.
+      description: Base64 encoded string that holds all information about the repository.
   required:
     - repo
   description: >
     Overrides the repository file with a custom repository for Infiniband installation.
+
+    Note: this file should be base64 encoded.
 
     On CentOS, the file is placed at /etc/yum.repos.d/infiniband.repo, while on Ubuntu it is at /etc/apt/sources.list.d/infiniband.list.
 install-infiniband:

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """SlurmdCharm."""
+import base64
 import logging
 
 from nrpe_external_master import Nrpe
@@ -201,6 +202,7 @@ class SlurmdCharm(CharmBase):
         """Set the infiniband repository."""
         repo = event.params["repo"]
         logger.debug(f"#### setting custom infiniband repo: {repo}")
+        repo = base64.b64decode(repo).decode()
         self._slurm_manager.infiniband.repository = repo
 
     def install_infiniband(self, event):

--- a/tests/30-infiniband.bats
+++ b/tests/30-infiniband.bats
@@ -22,7 +22,8 @@ myjuju () {
 }
 
 @test "Test changing the repo" {
-	juju run-action slurmd/leader set-infiniband-repo repo="new custom repo" --wait
+	repo=$(echo [new custom repo] | base64)
+	juju run-action slurmd/leader set-infiniband-repo repo="$repo" --wait
 
 	run juju run-action slurmd/leader get-infiniband-repo --wait
 	assert_output --partial "new custom repo"


### PR DESCRIPTION
Juju have difficulties processing strings with [] in them, so we need to
base64 encode the set-infiniband-repo action.