### PR TITLE
slurmrestd: remove trailing carriage return in version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ build
 tmp
 node_modules/
 .env
-VERSION
-charm-slurm*/VERSION
+version
+charm-slurm*/version
 charm-slurm*/README.md
 charm-slurm*/icon.svg
 charm-slurm*/LICENSE

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix slurmrestd version in Juju status breaking the line.
+
 0.6.3 - 2021-06-02
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ lint: ## Run linter
 	tox -e lint
 
 .PHONY: version
-version: ## Create/update VERSION file
-	@git describe --tags > VERSION
+version: ## Create/update version file
+	@git describe --tags > version
 
 .PHONY: readme
 readme: ## create charms' README.md
@@ -24,27 +24,27 @@ clean: ## Remove .tox, build dirs, and charms
 	rm -rf venv/
 	rm -rf *.charm
 	rm -rf charm-slurm*/build
-	rm -rf charm-slurm*/VERSION
+	rm -rf charm-slurm*/version
 	rm -rf charm-slurm*/README.md
 
 .PHONY: slurmd
 slurmd: version ## Build slurmd
-	@cp VERSION LICENSE icon.svg charm-slurmd/
+	@cp version LICENSE icon.svg charm-slurmd/
 	@charmcraft pack --project-dir charm-slurmd
 
 .PHONY: slurmctld
 slurmctld: version ## pack slurmctld
-	@cp VERSION LICENSE icon.svg charm-slurmctld/
+	@cp version LICENSE icon.svg charm-slurmctld/
 	@charmcraft pack --project-dir charm-slurmctld
 
 .PHONY: slurmdbd
 slurmdbd: version ## pack slurmdbd
-	@cp VERSION LICENSE icon.svg charm-slurmdbd/
+	@cp version LICENSE icon.svg charm-slurmdbd/
 	@charmcraft pack --project-dir charm-slurmdbd
 
 .PHONY: slurmrestd
 slurmrestd: version ## pack slurmrestd
-	@cp VERSION LICENSE icon.svg charm-slurmrestd/
+	@cp version LICENSE icon.svg charm-slurmrestd/
 	@charmcraft pack --project-dir charm-slurmrestd
 
 .PHONY: charms

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -138,7 +138,7 @@ class SlurmctldCharm(CharmBase):
 
     def _on_install(self, event):
         """Perform installation operations for slurmctld."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
         self.unit.status = WaitingStatus("Installing slurmctld")
 
@@ -167,7 +167,7 @@ class SlurmctldCharm(CharmBase):
 
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
     def _check_status(self):
         """Check for all relations and set appropriate status."""

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -66,7 +66,7 @@ class SlurmdCharm(CharmBase):
 
     def _on_install(self, event):
         """Perform installation operations for slurmd."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
         self.unit.status = WaitingStatus("Installing slurmd")
 
@@ -87,7 +87,7 @@ class SlurmdCharm(CharmBase):
 
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
     def _check_status(self) -> bool:
         """Check if we heve all needed components.

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -53,7 +53,7 @@ class SlurmdbdCharm(CharmBase):
 
     def _on_install(self, event):
         """Perform installation operations for slurmdbd."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
         self.unit.status = WaitingStatus("Installing slurmdbd")
 
@@ -73,7 +73,7 @@ class SlurmdbdCharm(CharmBase):
 
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
     def _on_slurmctld_available(self, event):
         if not self._stored.slurm_installed:

--- a/charm-slurmrestd/src/charm.py
+++ b/charm-slurmrestd/src/charm.py
@@ -46,7 +46,7 @@ class SlurmrestdCharm(CharmBase):
 
     def _on_install(self, event):
         """Perform installation operations for slurmrestd."""
-        self.unit.set_workload_version(Path("VERSION").read_text())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
         self.unit.status = WaitingStatus("Installing slurmrestd")
 
@@ -63,7 +63,7 @@ class SlurmrestdCharm(CharmBase):
 
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
-        self.unit.set_workload_version(Path("VERSION").read_text().strip())
+        self.unit.set_workload_version(Path("version").read_text().strip())
 
     def _on_restart_slurmrestd(self, event):
         """Resart the slurmrestd component."""


### PR DESCRIPTION
There was a trailing \n on the workload version of slurmrest charm.

This commit also changes the VERSION file to lowercase, as it is the way
to set the charm version for charmcraft and charmhub, see
https://github.com/canonical/charmcraft/issues/355