### PR TITLE
slurmd: set partition name on peer relation data

### DIFF
--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -139,6 +139,7 @@ class Slurmd(Object):
         slurmctld application(s) to observe the relation-changed
         event so they can acquire and redistribute the updated slurm config.
         """
+        # there is only one slurmctld, so there should be only one relation here
         relations = self._charm.framework.model.relations["slurmd"]
         for relation in relations:
             relation.data[self.model.app]["partition_info"] = json.dumps(

--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -27,7 +27,7 @@ class PeerRelationEvents(ObjectEvents):
 
 
 class SlurmdPeer(Object):
-    """TestingPeerRelation."""
+    """SlurmdPeerRelation."""
 
     on = PeerRelationEvents()
     _stored = StoredState()
@@ -75,8 +75,7 @@ class SlurmdPeer(Object):
 
     def get_slurmd_inventory(self):
         """Return slurmd inventory."""
-        relation = self.framework.model.get_relation(self._relation_name)
-
+        relation = self._relation
         # Comprise slurmd_info with the inventory of the active slurmd_peers
         # plus our own inventory.
         slurmd_peers = get_active_units(self._relation_name)
@@ -99,6 +98,16 @@ class SlurmdPeer(Object):
     @property
     def _relation(self):
         return self.framework.model.get_relation(self._relation_name)
+
+    @property
+    def partition_name(self):
+        """Get partition name."""
+        return self._relation.data[self.model.app].get('partition-name')
+
+    @partition_name.setter
+    def partition_name(self, name: str):
+        """Set the partition name."""
+        self._relation.data[self.model.app]['partition-name'] = name
 
     def configure_new_node(self):
         """Set this node as not new and trigger a reconfiguration."""

--- a/tests/10-slurm-partition.bats
+++ b/tests/10-slurm-partition.bats
@@ -16,8 +16,18 @@ myjuju () {
 	assert_output --partial "$partition "
 }
 
+@test "test partition name does not have spaces" {
+	partition="There are spaces here"
+	myjuju config slurmd partition-name="$partition"
+
+	run juju run --unit slurmctld/leader -m "$JUJU_MODEL" "sinfo"
+	refute_output --partial "$partition "
+	assert_output --partial "${partition// /-} "
+}
+
 @test "test we can set a default partition" {
 	partition="Unit-test-partition"
+	myjuju config slurmd partition-name="$partition"
 	myjuju config slurmctld default-partition="$partition"
 
 	run juju run --unit slurmctld/leader -m "$JUJU_MODEL" "sinfo"


### PR DESCRIPTION
This fixes a crash on all slurmd units when removing the leader of the
application. The partition name was stored in the leader, so removing it
looses this information and the slurm.conf is then scrambled.

This commit stores the partition name in the peer relation, so if the
leader is removed, we don't loose this information.

Add Bats test to assure partition names don't have spaces in them, as
spaces would break the slurm configuration file.