### PR TITLE
Ensure slurmd only starts if slurmctld accounts it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix race condition on inventory synchronization between slurmd and slurmctld
+  before starting slurmd
 - fix breakage in charms when the slurmd leader is removed
 - remove unused code in slurmd peer relation
 - fix slurmd action to query infiniband version

--- a/charm-slurmctld/src/interface_slurmd.py
+++ b/charm-slurmctld/src/interface_slurmd.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import logging
+from typing import List
 
 from ops.framework import (
     EventBase, EventSource, Object, ObjectEvents, StoredState
@@ -77,6 +78,11 @@ class Slurmd(Object):
         # send the hostname and port to enable configless mode
         app_relation_data["slurmctld_host"] = self._charm.hostname
         app_relation_data["slurmctld_port"] = self._charm.port
+
+    def set_list_of_accounted_nodes(self, nodes: List[str]):
+        """Set list of accounted for nodes in the app relation data."""
+        for relation in self._charm.framework.model.relations["slurmd"]:
+            relation.data[self.model.app]["unit_hostnames"] = json.dumps(nodes)
 
     def _on_relation_changed(self, event):
         """Emit slurmd available event."""

--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -19,7 +19,10 @@ class SlurmdPeer(Object):
     @property
     def partition_name(self) -> str:
         """Return the partition name from the application data."""
-        return self._relation.data[self.model.app].get("partition_name")
+        if self._relation:
+            if self._relation.data.get(self.model.app):
+                return self._relation.data[self.model.app].get("partition_name")
+        return ""
 
     @partition_name.setter
     def partition_name(self, partition_name: str):

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ exclude =
     mod,
 max-line-length = 99
 max-complexity = 10
-ignore = E261, E265, E501, I100, I201
+ignore = E261, E265, E501, D202, D204, I100, I201
 
 [isort]
 lines_after_imports = 2


### PR DESCRIPTION
This patch ensures slurmd nodes only try to start their daemon if
slurmctld received their inventories and updated the configuration file.
This prevents a race condition when slurmd tries to start the process
without slurmctld registering it in the slurm.conf, crashing slurmd.

Tests pass locally.