### PR TITLE
Slurmdbd events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix checks for munge when the code can't run subprocess as another UID
+
 0.6.5 - 2021-06-28
 ------------------
 

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.8
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.8
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.8
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -59,6 +59,15 @@ class Slurmdbd(Object):
             self._on_relation_broken,
         )
 
+    @property
+    def _relation(self):
+        return self.framework.model.get_relation(self._relation_name)
+
+    @property
+    def is_joined(self):
+        """Return True if juju related slurmdbd <-> slurmctld."""
+        return self._relation is not None
+
     def _on_relation_joined(self, event):
         """Handle the relation-joined event.
 
@@ -98,7 +107,6 @@ class Slurmdbd(Object):
     def _on_relation_broken(self, event):
         """Clear the application relation data and emit the event."""
         self.set_slurmdbd_info_on_app_relation_data("")
-        self._charm._stored.slurmctld_available = False
         self.on.slurmctld_unavailable.emit()
 
     def set_slurmdbd_info_on_app_relation_data(self, slurmdbd_info):

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.8
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9


### PR DESCRIPTION
Split slurmctld_available in 3 events

This allows finer control over 3 things that must happen when slurmctld
    is available:
    - configure the JWT RSA
    - configure munge key and start the daemon
    - write slurmdbd configuration and restart the daemon
    This change also improves the situation when one of those 3 events is
    deferred. Previously, one thing deferring would retrigger everything.
    Now, when one of those 3 events is deferred, it does not trigger the
    others.

Dependes on https://github.com/omnivector-solutions/slurm-ops-manager/pull/63