### PR TITLE
add charmcraft.yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ readme: ## create charms' README.md
 clean: ## Remove .tox, build dirs, and charms
 	rm -rf .tox/
 	rm -rf venv/
-	rm -rf *.charm
+	find . -name "*.charm" -delete
 	rm -rf charm-slurm*/build
 	rm -rf charm-slurm*/version
 	rm -rf charm-slurm*/README.md
@@ -31,21 +31,25 @@ clean: ## Remove .tox, build dirs, and charms
 slurmd: version ## Build slurmd
 	@cp version LICENSE icon.svg charm-slurmd/
 	@charmcraft pack --project-dir charm-slurmd
+	@cp charm-slurmd/slurmd_ubuntu-20.04-amd64_centos-7-amd64.charm slurmd.charm
 
 .PHONY: slurmctld
 slurmctld: version ## pack slurmctld
 	@cp version LICENSE icon.svg charm-slurmctld/
 	@charmcraft pack --project-dir charm-slurmctld
+	@cp charm-slurmctld/slurmctld_ubuntu-20.04-amd64_centos-7-amd64.charm slurmctld.charm
 
 .PHONY: slurmdbd
 slurmdbd: version ## pack slurmdbd
 	@cp version LICENSE icon.svg charm-slurmdbd/
 	@charmcraft pack --project-dir charm-slurmdbd
+	@cp charm-slurmdbd/slurmdbd_ubuntu-20.04-amd64_centos-7-amd64.charm slurmdbd.charm
 
 .PHONY: slurmrestd
 slurmrestd: version ## pack slurmrestd
 	@cp version LICENSE icon.svg charm-slurmrestd/
 	@charmcraft pack --project-dir charm-slurmrestd
+	@cp charm-slurmrestd/slurmrestd_ubuntu-20.04-amd64_centos-7-amd64.charm slurmrestd.charm
 
 .PHONY: charms
 charms: readme slurmd slurmdbd slurmctld slurmrestd ## Build all charms

--- a/charm-slurmctld/charmcraft.yaml
+++ b/charm-slurmctld/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64]
+      - name: centos
+        channel: "7"
+        architectures: [amd64]

--- a/charm-slurmd/charmcraft.yaml
+++ b/charm-slurmd/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64]
+      - name: centos
+        channel: "7"
+        architectures: [amd64]

--- a/charm-slurmdbd/charmcraft.yaml
+++ b/charm-slurmdbd/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64]
+      - name: centos
+        channel: "7"
+        architectures: [amd64]

--- a/charm-slurmrestd/charmcraft.yaml
+++ b/charm-slurmrestd/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64]
+      - name: centos
+        channel: "7"
+        architectures: [amd64]


### PR DESCRIPTION
With charmcraft 1.1.0, we need another YAML file in the repository,
charmcraft.yaml, that describes how to build and which OSes the charm
run. This patch adds the YAML file to build the charm on Ubuntu Focal
and run on Ubuntu Focal and CentOS7.

Charmcraft pack creates a horrible filename. We copy the file from the
project-dir to the root with a simpler filename, as to make it still
compatible with slurm-bundles.