### PR TITLE
Fix removal of a slurm partition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Unreleased
 0.6.6 - 2021-07-01
 ------------------
 
+- fix slurmctld crashing when removing a slurmd application
 - fix checks for munge when the code can't run subprocess as another UID
 
 0.6.5 - 2021-06-28

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -54,6 +54,7 @@ class SlurmctldCharm(CharmBase):
             self._slurmdbd.on.slurmdbd_unavailable: self._on_write_slurm_config,
             self._slurmd.on.slurmd_available: self._on_write_slurm_config,
             self._slurmd.on.slurmd_unavailable: self._on_write_slurm_config,
+            self._slurmd.on.slurmd_departed: self._on_write_slurm_config,
             self._slurmrestd.on.slurmrestd_available: self._on_slurmrestd_available,
             self._slurmrestd.on.slurmrestd_unavailable: self._on_write_slurm_config,
             self._slurmctld_peer.on.slurmctld_peer_available: self._on_write_slurm_config, # NOTE: a second slurmctld should get the jwt/munge keys and configure them

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -179,6 +179,7 @@ class SlurmdCharm(CharmBase):
         logger.debug("## Slurmctld unavailable")
         self._set_slurmctld_available(False)
         self._set_slurmctld_started(False)
+        self._slurm_manager.slurm_systemctl('stop')
         self._check_status()
 
     def _on_slurmctld_started(self, event):


### PR DESCRIPTION
This patch accounts for multiple SLURM partitions and fix
adding/removing relations between slurmctld and slurmd. When a slurmd
unit departs, it should stop its daemon, as it does not have all the
information needed up to date(host, port, mungekey). On slurmctld side,
it should only write the partitions in slurm.conf that have at least one
node, and never set slurmctld_available to False when there are other
slurmd applications.