### PR TITLE
Refactor partition names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Unreleased
 0.6.6 - 2021-07-01
 ------------------
 
+- change default partition name from juju-compute-random to osd-appname
 - fix slurmctld crashing when removing a slurmd application
 - fix checks for munge when the code can't run subprocess as another UID
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Unreleased
 0.6.6 - 2021-07-01
 ------------------
 
+- fix race condition on relation data exchange between slurmctld and slurmdbd
 - change default partition name from juju-compute-random to osd-appname
 - fix slurmctld crashing when removing a slurmd application
 - fix checks for munge when the code can't run subprocess as another UID

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -86,7 +86,7 @@ class SlurmctldCharm(CharmBase):
         return self._slurmdbd.get_slurmdbd_info()
 
     @property
-    def _slurmd_info(self):
+    def _slurmd_info(self) -> list:
         return self._slurmd.get_slurmd_info()
 
     @property

--- a/charm-slurmctld/src/interface_slurmd.py
+++ b/charm-slurmctld/src/interface_slurmd.py
@@ -125,7 +125,7 @@ class Slurmd(Object):
         """Return True if self._relation is not None."""
         return self._num_relations > 0
 
-    def get_slurmd_info(self):
+    def get_slurmd_info(self) -> list:
         """Return the node info for units of applications on the relation."""
         partitions = list()
         relations = self.framework.model.relations["slurmd"]
@@ -138,7 +138,14 @@ class Slurmd(Object):
             # check if this partition has at least one node before adding it to
             # the list
             if units:
-                partition_info = json.loads(relation.data[app]["partition_info"])
+                if not relation.data.get(app):
+                    logger.debug(f"## Not app data in relation with {app}")
+                    return []
+                if not relation.data[app].get("partition_info"):
+                    logger.debug("## Not partition info data in relation")
+                    return []
+
+                partition_info = json.loads(relation.data[app].get("partition_info"))
 
                 for unit in units:
                     inv = relation.data[unit].get("inventory")

--- a/charm-slurmd/src/interface_slurmd_peer.py
+++ b/charm-slurmd/src/interface_slurmd_peer.py
@@ -27,7 +27,8 @@ class SlurmdPeer(Object):
     @partition_name.setter
     def partition_name(self, partition_name: str):
         """Set the partition name on the application data."""
-        self._relation.data[self.model.app]["partition_name"] = partition_name
+        if self._relation:
+            self._relation.data[self.model.app]["partition_name"] = partition_name
 
     @property
     def available(self) -> bool:

--- a/tests/00-slurm-init.bats
+++ b/tests/00-slurm-init.bats
@@ -14,7 +14,7 @@ myjuju () {
 	assert_success
 
 	# slurmd node in down state
-	assert_line --regexp "juju-compute-[a-zA-Z ]+up *infinite *1 *down.*"
+	assert_line --regexp "osd-slurmd +up *infinite *1 *down.*"
 }
 
 @test "test first node is down because it is new" {


### PR DESCRIPTION
This patch improves the code that sets the partition name of a Juju
slurmd application. It fixes a race condition where the partition-name
is set in a bundle YAML file, but it is not propagated to the charm
state.
It also changes the default partition name to osd-{appname} instead of
juju-compute-randomstring.

To be merged after #101 