### PR TITLE
update slurmrestd relation with ctld

### DIFF
--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -362,14 +362,10 @@ class SlurmctldCharm(CharmBase):
             self._resume_nodes(configured_nodes)
             self._stored.down_nodes = down_nodes.copy()
 
-            # NOTE: does it make sense to do this here?
-            # slurmrestd needs the slurm.conf file, so send it
+            # slurmrestd needs the slurm.conf file, so send it every time it changes
             if self._stored.slurmrestd_available:
-                self._slurmrestd.set_slurm_config_on_app_relation_data(
-                    slurm_config
-                )
-                # NOTE: check if we really need to restart slurmrestd. scontrol
-                #       reconfigure might be enough
+                self._slurmrestd.set_slurm_config_on_app_relation_data(slurm_config)
+                # NOTE: scontrol reconfigure does not restart slurmrestd
                 self._slurmrestd.restart_slurmrestd()
         else:
             logger.debug("## Should rewrite slurm.conf, but we don't have it. "

--- a/charm-slurmctld/src/interface_slurmrestd.py
+++ b/charm-slurmctld/src/interface_slurmrestd.py
@@ -34,6 +34,8 @@ class Slurmrestd(Object):
         super().__init__(charm, relation_name)
 
         self._charm = charm
+        self._relation_name = relation_name
+
         self.framework.observe(
             self._charm.on[relation_name].relation_created,
             self._on_relation_created
@@ -75,24 +77,21 @@ class Slurmrestd(Object):
         self._charm.set_slurmrestd_available(False)
         self.on.slurmrestd_unavailable.emit()
 
-    def set_slurm_config_on_app_relation_data(
-        self,
-        slurm_config,
-    ):
+    def set_slurm_config_on_app_relation_data(self, slurm_config):
         """Set the slurm_conifg to the app data on the relation.
 
         Setting data on the relation forces the units of related applications
         to observe the relation-changed event so they can acquire and
         render the updated slurm_config.
         """
-        relations = self._charm.framework.model.relations["slurmrestd"]
+        relations = self._charm.framework.model.relations.get(self._relation_name)
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
             app_relation_data["slurm_config"] = json.dumps(slurm_config)
 
     def restart_slurmrestd(self):
         """Send a restart signal to related slurmd applications."""
-        relations = self._charm.framework.model.relations["slurmrestd"]
+        relations = self._charm.framework.model.relations.get(self._relation_name)
         for relation in relations:
             app_relation_data = relation.data[self.model.app]
             app_relation_data["restart_slurmrestd_uuid"] = str(uuid.uuid4())


### PR DESCRIPTION
Review slurmrestd <-> slurmctld relation to:
- update status message displayed with `juju status`, to show relations
  needed and waiting on
- fix missing internal cache values for munge/jwt keys