### PR TITLE
Add update-status hook handler

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- handle update-status hook to constantly give feedback about charms' status
 - add .jujuignore to reduce size of final charm files
 - fix cache of partition_name in slurmd charm
 - improve description of charm's state in juju status

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -49,6 +49,7 @@ class SlurmctldCharm(CharmBase):
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.upgrade_charm: self._on_upgrade,
+            self.on.update_status: self._on_update_status,
             self.on.config_changed: self._on_write_slurm_config,
             self._slurmdbd.on.slurmdbd_available: self._on_slurmdbd_available,
             self._slurmdbd.on.slurmdbd_unavailable: self._on_slurmdbd_unavailable,
@@ -176,6 +177,10 @@ class SlurmctldCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+
+    def _on_update_status(self, event):
+        """Handle update status."""
+        self._check_status()
 
     def _check_status(self):
         """Check for all relations and set appropriate status.

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -52,6 +52,7 @@ class SlurmdCharm(CharmBase):
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.upgrade_charm: self._on_upgrade,
+            self.on.update_status: self._on_update_status,
             self.on.config_changed: self._on_config_changed,
             self.on.slurmd_start: self._on_slurmd_start,
             self._slurmd.on.slurmctld_available: self._on_slurmctld_available,
@@ -94,6 +95,10 @@ class SlurmdCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+
+    def _on_update_status(self, event):
+        """Handle update status."""
+        self._check_status()
 
     def _check_status(self) -> bool:
         """Check if we heve all needed components.

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -62,6 +62,7 @@ class SlurmdbdCharm(CharmBase):
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.upgrade_charm: self._on_upgrade,
+            self.on.update_status: self._on_update_status,
             self.on.config_changed: self._write_config_and_restart_slurmdbd,
             self.on.jwt_available: self._on_jwt_available,
             self.on.munge_available: self._on_munge_available,
@@ -96,6 +97,10 @@ class SlurmdbdCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+
+    def _on_update_status(self, event):
+        """Handle update status."""
+        self._check_status()
 
     def _on_jwt_available(self, event):
         """Retrieve and configure the jwt_rsa key."""

--- a/charm-slurmrestd/src/charm.py
+++ b/charm-slurmrestd/src/charm.py
@@ -38,6 +38,7 @@ class SlurmrestdCharm(CharmBase):
         event_handler_bindings = {
             self.on.install: self._on_install,
             self.on.upgrade_charm: self._on_upgrade,
+            self.on.update_status: self._on_update_status,
             self._slurmrestd.on.config_available: self._on_check_status_and_write_config,
             self._slurmrestd.on.config_unavailable: self._on_config_unavailable,
             self._slurmrestd.on.munge_key_available: self._on_configure_munge_key,
@@ -69,6 +70,10 @@ class SlurmrestdCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+        self._check_status()
+
+    def _on_update_status(self, event):
+        """Handle update status."""
         self._check_status()
 
     def _on_config_unavailable(self, event):


### PR DESCRIPTION
Add an event handler to run check_status() every 5 minutes (or the
interval specified with juju model-config update-status-hook-interval).