### PR TITLE
add influxdb and grafana relations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add acct gather configuration options
 - handle update-status hook to constantly give feedback about charms' status
 - add .jujuignore to reduce size of final charm files
 - fix cache of partition_name in slurmd charm

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add grafana relation for slurmctld
+- add influxdb relation for accouting and profiling of jobs with the SLURM
+  InfluxDB plugin
 - add acct gather configuration options
 - handle update-status hook to constantly give feedback about charms' status
 - add .jujuignore to reduce size of final charm files

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add influxdb-info action to slurmctld
 - add grafana relation for slurmctld
 - add influxdb relation for accouting and profiling of jobs with the SLURM
   InfluxDB plugin

--- a/charm-slurmctld/actions.yaml
+++ b/charm-slurmctld/actions.yaml
@@ -38,3 +38,10 @@ resume:
         The nodes to resume, using the Slurm format, e.g. `node-[1,2]`.
   required:
     - nodename
+
+influxdb-info:
+  description: >
+    Get InfluxDB info.
+
+    This action returns the host, port, username, password, database, and
+    retention policy regarding to InfluxDB.

--- a/charm-slurmctld/config.yaml
+++ b/charm-slurmctld/config.yaml
@@ -45,3 +45,23 @@ options:
     default: "ANY,CYCLE"
     type: string
     description: Only run the Health Check on nodes in this state.
+
+  acct-gather-frequency:
+    type: string
+    default: "task=30"
+    description: >
+      Accounting and profiling sampling intervals for the acct_gather plugins.
+
+      Note: a value of `0` disables the periodic sampling. In this case, the
+      accounting information is collected when the job terminates.
+
+      Example usage:
+      $ juju config slurmcltd acct-gather-frequency="task=30,network=30"
+  acct-gather-custom:
+    type: string
+    default: ""
+    description: >
+      User supplied `acct_gather.conf` configuration.
+
+      This value supplements the charm supplied `acct_gather.conf` file that is
+      used for configuring the acct_gather plugins.

--- a/charm-slurmctld/metadata.yaml
+++ b/charm-slurmctld/metadata.yaml
@@ -35,3 +35,10 @@ requires:
     interface: slurmdbd
   slurmrestd:
     interface: slurmrestd
+  influxdb-api:
+    interface: influxdb-api
+
+provides:
+  grafana-source:
+    interface: grafana-source
+    scope: global

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,3 +1,4 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
+influxdb
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -74,6 +74,7 @@ class SlurmctldCharm(CharmBase):
             self.on.show_current_config_action: self._on_show_current_config,
             self.on.drain_action: self._drain_nodes_action,
             self.on.resume_action: self._resume_nodes_action,
+            self.on.influxdb_info_action: self._infludb_info_action,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -498,6 +499,14 @@ class SlurmctldCharm(CharmBase):
             event.set_results({'status': 'resuming', 'nodes': nodes})
         except subprocess.CalledProcessError as e:
             event.fail(message=f'Error resuming {nodes}: {e.output}')
+
+    def _infludb_info_action(self, event):
+        influxdb_info = self._get_influxdb_info()
+
+        if not influxdb_info:
+            influxdb_info = "not related"
+        logger.debug(f"## InfluxDB-info action: {influxdb_info}")
+        event.set_results({"influxdb": influxdb_info})
 
 
 if __name__ == "__main__":

--- a/charm-slurmctld/src/interface_grafana_source.py
+++ b/charm-slurmctld/src/interface_grafana_source.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Grafana Source Interface."""
+import logging
+
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+
+logger = logging.getLogger()
+
+
+class GrafanaSourceAvailableEvent(EventBase):
+    """GrafanaSourceAvailable event."""
+
+
+class GrafanaSourceEvents(ObjectEvents):
+    """GrafanaSourceEvents."""
+
+    grafana_available = EventSource(GrafanaSourceAvailableEvent)
+
+
+class GrafanaSource(Object):
+    """Grafana Source Interface."""
+
+    on = GrafanaSourceEvents()
+
+    def __init__(self, charm, relation_name):
+        """Observe relation events."""
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_joined,
+            self._on_relation_joined,
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _on_relation_joined(self, event):
+        if self.framework.model.unit.is_leader():
+            self.on.grafana_available.emit()
+
+    def _on_relation_broken(self, event):
+        if self.framework.model.unit.is_leader():
+            app_relation_data = self._relation.data[self.model.app]
+            app_relation_data["url"] = ""
+            app_relation_data["username"] = ""
+            app_relation_data["password"] = ""
+            app_relation_data["database"] = ""
+
+    @property
+    def _relation(self):
+        return self.framework.model.get_relation(self._relation_name)
+
+    @property
+    def is_joined(self) -> bool:
+        """Return True if self._relation is not None."""
+        return self._relation is not None
+
+    def set_grafana_source_info(self, influxdb: dict):
+        """Set grafana source info on relation."""
+        logger.debug("## sending data to grafana")
+
+        if self.framework.model.unit.is_leader():
+            app_relation_data = self._relation.data[self.model.app]
+            app_relation_data["type"] = "influxdb"
+            app_relation_data["url"] = f"{influxdb['ingress']}:{influxdb['port']}"
+            app_relation_data["username"] = influxdb["user"]
+            app_relation_data["password"] = influxdb["password"]
+            app_relation_data["database"] = influxdb["database"]

--- a/charm-slurmctld/src/interface_influxdb.py
+++ b/charm-slurmctld/src/interface_influxdb.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""AcctGather (Influxdb) interface."""
+import json
+import logging
+import secrets
+import string
+
+import influxdb
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, \
+                          StoredState
+
+logger = logging.getLogger()
+
+
+class InfluxDBAvailableEvent(EventBase):
+    """InfluxDBAvailable event."""
+
+
+class InfluxDBUnAvailableEvent(EventBase):
+    """InfluxDBUnAvailable event."""
+
+
+class InfluxDBEvents(ObjectEvents):
+    """InfluxDBEvents."""
+
+    influxdb_available = EventSource(InfluxDBAvailableEvent)
+    influxdb_unavailable = EventSource(InfluxDBUnAvailableEvent)
+
+
+def generate_password(length=20):
+    """Generate a random password."""
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+
+class InfluxDB(Object):
+    """InfluxDB interface."""
+
+    _stored = StoredState()
+    on = InfluxDBEvents()
+
+    _INFLUX_USER = "slurm"
+    _INFLUX_DATABASE = "slurm"
+    _INFLUX_PRIVILEGE = "all"
+
+    def __init__(self, charm, relation_name):
+        """Observe relation events."""
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        self._stored.set_default(
+            influxdb_info=str(),
+            influxdb_admin_info=str(),
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed,
+            self._on_relation_changed,
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _on_relation_changed(self, event):
+        """Store influxdb_ingress in the charm."""
+        if self.framework.model.unit.is_leader():
+            if not self._stored.influxdb_admin_info:
+                ingress = event.relation.data[event.unit]["ingress-address"]
+                port = event.relation.data[event.unit].get("port")
+                user = event.relation.data[event.unit].get("user")
+                password = event.relation.data[event.unit].get("password")
+
+                if all([ingress, port, user, password]):
+                    admin_info = {"ingress": ingress,
+                                  "port": port,
+                                  "user": user,
+                                  "password": password}
+                    self._stored.influxdb_admin_info = json.dumps(admin_info)
+
+                    # Influxdb client
+                    client = influxdb.InfluxDBClient(ingress,
+                                                     port,
+                                                     user,
+                                                     password)
+
+                    # Influxdb slurm user password
+                    influx_slurm_password = generate_password()
+
+                    # Only create the user and db if they don't already exist
+                    users = [db["user"] for db in client.get_list_users()]
+                    if self._INFLUX_USER not in users:
+                        client.create_user(self._INFLUX_DATABASE,
+                                           influx_slurm_password)
+
+                    databases = [db["name"] for db in client.get_list_database()]
+                    if self._INFLUX_DATABASE not in databases:
+                        client.create_database(self._INFLUX_DATABASE)
+
+                    client.grant_privilege(self._INFLUX_PRIVILEGE,
+                                           self._INFLUX_DATABASE,
+                                           self._INFLUX_USER)
+
+                    # select default retention policy
+                    policies = client.get_list_retention_policies(self._INFLUX_DATABASE)
+                    policy = "slurm"
+                    for p in policies:
+                        if p["default"]:
+                            policy = p["name"]
+
+                    # Dump influxdb_info to json and set it to state
+                    influxdb_info = {"ingress": ingress,
+                                     "port": port,
+                                     "user": self._INFLUX_USER,
+                                     "password": influx_slurm_password,
+                                     "database": self._INFLUX_DATABASE,
+                                     "retention_policy": policy}
+                    self._stored.influxdb_info = json.dumps(influxdb_info)
+                    self.on.influxdb_available.emit()
+
+    def _on_relation_broken(self, event):
+        """Remove the database and user from influxdb."""
+        if self.framework.model.unit.is_leader():
+            if self._stored.influxdb_admin_info:
+                influxdb_admin_info = json.loads(self._stored.influxdb_admin_info)
+
+                client = influxdb.InfluxDBClient(influxdb_admin_info["ingress"],
+                                                 influxdb_admin_info["port"],
+                                                 influxdb_admin_info["user"],
+                                                 influxdb_admin_info["password"])
+
+                databases = [db["name"] for db in client.get_list_database()]
+                if self._INFLUX_DATABASE in databases:
+                    client.drop_database(self._INFLUX_DATABASE)
+
+                users = [db["user"] for db in client.get_list_users()]
+                if self._INFLUX_USER in users:
+                    client.drop_user(self._INFLUX_USER)
+
+                self._stored.influxdb_info = ""
+                self._stored.influxdb_admin_info = ""
+                self.on.influxdb_unavailable.emit()
+
+    def get_influxdb_info(self) -> dict:
+        """Return the influxdb info."""
+        influxdb_info = self._stored.influxdb_info
+        if influxdb_info:
+            return json.loads(influxdb_info)
+        else:
+            return {}

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.9
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10

--- a/tests/15-acct-gather.bats
+++ b/tests/15-acct-gather.bats
@@ -1,0 +1,25 @@
+#!/bin/npx bats
+
+load "../node_modules/bats-support/load"
+load "../node_modules/bats-assert/load"
+
+
+myjuju () {
+	juju "$@"
+	juju-wait -t 540 -m $JUJU_MODEL
+}
+
+
+@test "Assert we can update JobAcctGatherFrequency" {
+	freq="task=$RANDOM"
+	myjuju config slurmctld acct-gather-frequency="$freq"
+	# we need to wait scontrol reconfigure to finish, this is not reflected
+	# on Juju status
+	sleep 5
+
+	run juju run --unit slurmctld/leader "grep JobAcctGatherFrequency /etc/slurm/slurm.conf"
+	assert_output "JobAcctGatherFrequency=$freq"
+
+	run juju run --unit slurmd/leader "grep JobAcctGatherFrequency /run/slurm/conf/slurm.conf"
+	assert_output "JobAcctGatherFrequency=$freq"
+}

--- a/tests/15-acct-gather.bats
+++ b/tests/15-acct-gather.bats
@@ -23,3 +23,8 @@ myjuju () {
 	run juju run --unit slurmd/leader "grep JobAcctGatherFrequency /run/slurm/conf/slurm.conf"
 	assert_output "JobAcctGatherFrequency=$freq"
 }
+
+@test "Assert we can run-action influxdb-info" {
+	run juju run-action slurmctld/leader influxdb-info --wait --format=json
+	assert_output --partial "not related"
+}

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ exclude =
     mod,
 max-line-length = 99
 max-complexity = 10
-ignore = E261, E265, E501, D202, D204, I100, I201, W503
+ignore = E126, E261, E265, E501, D202, D204, I100, I201, W503
 
 [isort]
 lines_after_imports = 2


### PR DESCRIPTION
Depends on https://github.com/omnivector-solutions/slurm-ops-manager/pull/64

- Add relation to infuxdb, to use the SLURM InfluxDB accounting plugin.
  This plugin allows job profiling. Two new configuration options added:
  - acct-gather-frequency: the sampling interval for the acct_gather
    plugins.
  - acct-gather-custom: the custom values for the acct_gather.conf file.

- Add relation to grafana. This relation depends on the influxdb relation:
  when relating to grafana, send the information about the influxdb (host,
  port, user, pass, bucket) as a data-source for dashboards.

- Test we can alter the JobAcctGatherFrequency and propagate the changes
  to all nodes.

- slurmctld: add influxdb-info action

  This action returns a dictionary with the host, port, username,
  password, database, and retention policy regarding to InfluxDB. This
  allows one to configure Grafana easily.

