### PR TITLE
Add support for Ubuntu partitions on CentOS deploys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add support for Ubuntu partitions on CentOS deploys
 - add influxdb-info action to slurmctld
 - add grafana relation for slurmctld
 - add influxdb relation for accouting and profiling of jobs with the SLURM

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,4 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.10
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11


### PR DESCRIPTION
Add support for Ubuntu partitions on CentOS deploys.

Depends on: https://github.com/omnivector-solutions/slurm-ops-manager/pull/65

To run it:
```bash
$ cd slurm-bundles
$ make lxd-centos
$ cd ../slurm-charms
$ juju deploy ./slurmd.charm slurmd-ubuntu
$ juju relate slurmd-ubuntu slurmctld
```