### PR TITLE
bump slurm-ops-manager to use the gpg from file branch

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- install bullseye gpg keys from files
 - add support for Ubuntu partitions on CentOS deploys
 - add influxdb-info action to slurmctld
 - add grafana relation for slurmctld

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
-- install bullseye gpg keys from files
+- fix #111: install bullseye gpg keys from files
 - add support for Ubuntu partitions on CentOS deploys
 - add influxdb-info action to slurmctld
 - add grafana relation for slurmctld

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,4 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,4 @@
 ops
 influxdb
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.11
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@add_apt_gpg_keys_for_bullseye
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**
These changes introduce the latest [slurm-ops-manager](https://github.com/omnivector-solutions/slurm-ops-manager/pull/66) which installs the bullseye gpg keys from a file for the ubuntu slurm installations. 

This fixes charm install errors when the network environment restricts access to upstream keyservers.

**How was the code tested?**
Deployed in production environment with keyserver restrictions.
