### PR TITLE
Use etcd for internal accounting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,5 @@ Final checklist
 - [ ] I am the author of these changes, or I have the rights to submit them.
 - [ ] I added the relevant changed to the README and/or documentation.
 - [ ] I self reviewed my own code.
+- [ ] I updated the `CHANGELOG` according to the [contributing
+  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)

--- a/.github/workflows/test_build_release_edge.yaml
+++ b/.github/workflows/test_build_release_edge.yaml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
       - name: "Install charmcraft"
         run: |
-          sudo snap install charmcraft --channel=latest/candidate --classic
+          sudo snap install charmcraft --channel=latest/stable --classic
       - name: "Install lxd"
         run: |
           sudo snap install lxd --channel=latest/stable

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix: reduce number of events when a slurmd unit is added/removed
 - fix #111: install bullseye gpg keys from files
 - add support for Ubuntu partitions on CentOS deploys
 - add influxdb-info action to slurmctld

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint: ## Run linter
 
 .PHONY: version
 version: ## Create/update version file
-	@git describe --tags > version
+	@git describe --tags --dirty > version
 
 .PHONY: readme
 readme: ## create charms' README.md

--- a/charm-slurmctld/metadata.yaml
+++ b/charm-slurmctld/metadata.yaml
@@ -42,3 +42,11 @@ provides:
   grafana-source:
     interface: grafana-source
     scope: global
+
+resources:
+  etcd:
+    type: file
+    filename: etcd-v3.5.0-linux-amd64.tar.gz
+    description: >
+      Official tarball containing the compiled etcd binaries. Retrieved from
+      GitHub Releases.

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,5 @@
 ops
 influxdb
+etcd3gw==1.0.0
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/src/etcd_ops.py
+++ b/charm-slurmctld/src/etcd_ops.py
@@ -1,0 +1,101 @@
+"""etcd operations."""
+
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+import tarfile
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from typing import List
+
+from etcd3gw.client import Etcd3Client
+
+logger = logging.getLogger()
+
+
+class EtcdOps:
+    """ETCD ops."""
+
+    def __init__(self):
+        """Initialize class."""
+        # system user and group
+        self._etcd_user = "etcd"
+        self._etcd_group = "etcd"
+        self._etcd_service = "etcd.service"
+
+    def install(self, resource_path: Path):
+        """Install etcd."""
+        # extract resource tarball
+        with TemporaryDirectory(prefix="omni") as tmp_dir:
+            logger.debug(f"## extracting {resource_path} to {tmp_dir}")
+            with tarfile.open(resource_path, 'r') as tar:
+                tar.extractall(path=tmp_dir)
+
+            usrbin = Path("/usr/bin")
+            logger.debug(f"## installing etcd in {usrbin}")
+            source = Path(tmp_dir) / "etcd-v3.5.0-linux-amd64"
+            for abin in ["etcd", "etcdutl", "etcdctl"]:
+                shutil.copy2(source / abin, usrbin / abin)
+
+        self._create_etcd_user_group()
+
+        varlib = Path("/var/lib/etcd")
+        if not varlib.exists():
+            varlib.mkdir()
+        shutil.chown(varlib, user=self._etcd_user, group=self._etcd_group)
+
+        self._setup_systemd()
+
+    def _create_etcd_user_group(self):
+        logger.debug("## creating etcd user and group")
+        cmd = f"groupadd {self._etcd_group}"
+        subprocess.call(shlex.split(cmd))
+
+        subprocess.call(["useradd",
+                         "--system",
+                         "--no-create-home",
+                         f"--gid={self._etcd_group}",
+                         "--shell=/usr/sbin/nologin",
+                         self._etcd_user])
+
+    def _setup_systemd(self):
+        logger.debug("## creating systemd files for etcd")
+
+        charm_dir = Path(__file__).parent
+        template_dir = Path(charm_dir) / "templates"
+        source = template_dir / "etcd.service.tmpl"
+        dest = Path("/etc/systemd/system/") / self._etcd_service
+        shutil.copy2(source, dest)
+
+        subprocess.call(["systemctl", "daemon-reload"])
+
+    def start(self):
+        """Start etcd service."""
+        logger.debug("## enabling and starting etcd")
+        subprocess.call(["systemctl", "enable", self._etcd_service])
+        subprocess.call(["systemctl", "start", self._etcd_service])
+
+    def is_active(self) -> bool:
+        """Check if systemd etcd service is active."""
+        try:
+            cmd = f"systemctl is-active {self._etcd_service}"
+            r = subprocess.check_output(shlex.split(cmd))
+            return 'active' == r.decode().strip().lower()
+        except subprocess.CalledProcessError as e:
+            logger.error(f'## Could not check etcd: {e}')
+            return False
+
+    def configure(self):
+        """Configure etcd instance."""
+        # TODO set up password?
+        # TODO set up port?
+        # TODO enable metrics? Relate to prometheus?
+        logger.debug("## configuring etcd")
+
+    def set_list_of_accounted_nodes(self, nodes: List[str]) -> None:
+        """Set list of nodes on etcd."""
+        logger.debug(f"## setting on etcd: all_nodes/{nodes}")
+        client = Etcd3Client(api_path="/v3/")
+        client.put(key="all_nodes", value=json.dumps(nodes))

--- a/charm-slurmctld/src/interface_slurmd.py
+++ b/charm-slurmctld/src/interface_slurmd.py
@@ -3,7 +3,6 @@
 import copy
 import json
 import logging
-from typing import List
 
 from ops.framework import (
     EventBase, EventSource, Object, ObjectEvents, StoredState
@@ -78,11 +77,7 @@ class Slurmd(Object):
         # send the hostname and port to enable configless mode
         app_relation_data["slurmctld_host"] = self._charm.hostname
         app_relation_data["slurmctld_port"] = self._charm.port
-
-    def set_list_of_accounted_nodes(self, nodes: List[str]):
-        """Set list of accounted for nodes in the app relation data."""
-        for relation in self._charm.framework.model.relations["slurmd"]:
-            relation.data[self.model.app]["unit_hostnames"] = json.dumps(nodes)
+        app_relation_data["etcd_port"] = "2379"
 
     def _on_relation_changed(self, event):
         """Emit slurmd available event."""

--- a/charm-slurmctld/src/templates/etcd.service.tmpl
+++ b/charm-slurmctld/src/templates/etcd.service.tmpl
@@ -1,0 +1,21 @@
+[Unit]
+Description=etcd key-value store
+Documentation=https://github.com/etcd-io/etcd
+After=network-online.target local-fs.target remote-fs.target time-sync.target
+Wants=network-online.target local-fs.target remote-fs.target time-sync.target
+
+[Service]
+User=etcd
+Group=etcd
+Type=notify
+Environment=ETCD_DATA_DIR=/var/lib/etcd
+Environment=ETCD_NAME=osd-etcd
+Environment=ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+Environment=ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+ExecStart=/usr/bin/etcd
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,4 @@
 ops
+etcd3gw==1.0.0
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.6.12
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ exclude =
     mod,
 max-line-length = 99
 max-complexity = 10
-ignore = E126, E261, E265, E501, D202, D204, I100, I201, W503
+ignore = E126, E127, E261, E265, E501, D202, D204, I100, I201, W503
 
 [isort]
 lines_after_imports = 2


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Use etcd for internal node accounting, to reduce the number of events fired when performing Juju Operations.

**How was the code tested?**

Download the etc tarbal from [here](https://github.com/etcd-io/etcd/releases/download/v3.5.0/etcd-v3.5.0-linux-amd64.tar.gz) and deploy `slurmcltld` with `juju  deploy ./slurmctld.charm --series centos7 --resource etcd=etcd-v3.5.0-linux-amd64.tar.gz`. Use the `slurm-bundles` from https://github.com/omnivector-solutions/slurm-bundles/pull/21 to automatically use the etcd resource.

`make tests` pass on my local setup :)

Followup docs: https://github.com/omnivector-solutions/osd-documentation/pull/34

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
