### PR TITLE
make sure we have git when packing the charm

### DIFF
--- a/charm-slurmctld/charmcraft.yaml
+++ b/charm-slurmctld/charmcraft.yaml
@@ -10,3 +10,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
+parts:
+  charm:
+    build-packages: [git]

--- a/charm-slurmd/charmcraft.yaml
+++ b/charm-slurmd/charmcraft.yaml
@@ -10,3 +10,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
+parts:
+  charm:
+    build-packages: [git]

--- a/charm-slurmdbd/charmcraft.yaml
+++ b/charm-slurmdbd/charmcraft.yaml
@@ -10,3 +10,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
+parts:
+  charm:
+    build-packages: [git]

--- a/charm-slurmrestd/charmcraft.yaml
+++ b/charm-slurmrestd/charmcraft.yaml
@@ -10,3 +10,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
+parts:
+  charm:
+    build-packages: [git]


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Fresh installs of charmcraft will not contain git, starting with 1.2.0. This patch adds git
as build dependency. See https://github.com/canonical/charmcraft/issues/490.

Addresses #112

**How was the code tested?**

Please describe the conditions under which the code has been tested.


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
