### PR TITLE
Bump slurm-ops-manager from 0.7.2 to XX

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,8 +7,9 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix changing infiniband repos on Ubuntu
+- fix fluentbit parser for slurm logs
 - fix creation of user and group when those already exist
-
 
 0.8.1 - 2021-10-07
 ------------------

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,5 @@
 ops
 influxdb
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,4 @@
 ops
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

- fix changing infiniband repos on Ubuntu
- fix fluentbit parser for slurm logs

**How was the code tested?**

Please describe the conditions under which the code has been tested.

Depends on https://github.com/omnivector-solutions/slurm-ops-manager/pull/71

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
