### PR TITLE
Enrich fluentbit logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add labels to Fluentbit logs: cluster-name, partition-name, hostname, service
+
 0.8.2 - 2021-10-13
 ------------------
 

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,5 @@
 ops
 influxdb
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.4
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -99,6 +99,11 @@ class SlurmctldCharm(CharmBase):
         return self._slurm_manager.port
 
     @property
+    def cluster_name(self) -> str:
+        """Return the cluster name."""
+        return self.config.get("cluster-name")
+
+    @property
     def _slurmctld_info(self):
         return self._slurmctld_peer.get_slurmctld_info()
 

--- a/charm-slurmctld/src/interface_slurmd.py
+++ b/charm-slurmctld/src/interface_slurmd.py
@@ -79,6 +79,8 @@ class Slurmd(Object):
         app_relation_data["slurmctld_port"] = self._charm.port
         app_relation_data["etcd_port"] = "2379"
 
+        app_relation_data["cluster_name"] = self._charm.config.get("cluster-name")
+
     def _on_relation_changed(self, event):
         """Emit slurmd available event."""
         if event.relation.data[event.app].get("partition_info"):

--- a/charm-slurmctld/src/interface_slurmdbd.py
+++ b/charm-slurmctld/src/interface_slurmdbd.py
@@ -74,6 +74,8 @@ class Slurmdbd(Object):
         jwt_rsa = self._charm.get_jwt_rsa()
         event.relation.data[self.model.app]["jwt_rsa"] = jwt_rsa
 
+        event.relation.data[self.model.app]["cluster-name"] = self._charm.config.get("cluster-name")
+
     def _on_relation_changed(self, event):
         event_app_data = event.relation.data.get(event.app)
         if event_app_data:

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,4 @@
 ops
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.4
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -80,8 +80,8 @@ class Slurmd(Object):
         """
         Handle the relation-joined event.
 
-        Get the munge_key, slurmctld_host and slurmctld_port, and etcd port
-        from slurmctld and save it to the charm stored state.
+        Get the munge_key, slurmctld_host and slurmctld_port, etcd port, and
+        the cluster name from slurmctld and save it to the charm stored state.
         """
         app_data = event.relation.data[event.app]
         if not app_data.get("munge_key"):
@@ -100,6 +100,7 @@ class Slurmd(Object):
                                         slurmctld_addr)
         self.etcd_port = app_data["etcd_port"]
 
+        self._charm.cluster_name = app_data.get("cluster_name")
         self.on.slurmctld_available.emit()
 
     def _on_relation_broken(self, event):

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.4
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -53,6 +53,7 @@ class SlurmdbdCharm(CharmBase):
             jwt_available=False,
             munge_available=False,
             slurm_installed=False,
+            cluster_name=str()
         )
 
         self._db = MySQLClient(self, "db")
@@ -102,6 +103,9 @@ class SlurmdbdCharm(CharmBase):
 
     def _on_fluentbit_relation_created(self, event):
         """Set up Fluentbit log forwarding."""
+        self._configure_fluentbit()
+
+    def _configure_fluentbit(self):
         logger.debug("## Configuring fluentbit")
         cfg = list()
         cfg.extend(self._slurm_manager.fluentbit_config_nhc)
@@ -155,6 +159,8 @@ class SlurmdbdCharm(CharmBase):
         self.on.munge_available.emit()
 
         self.on.write_config.emit()
+        if self._fluentbit._relation is not None:
+            self._configure_fluentbit()
 
     def _on_slurmctld_unavailable(self, event):
         """Reset state and charm status when slurmctld broken."""
@@ -279,6 +285,16 @@ class SlurmdbdCharm(CharmBase):
     def set_db_info(self, db_info):
         """Set the db_info in the stored state."""
         self._stored.db_info = db_info
+
+    @property
+    def cluster_name(self) -> str:
+        """Return the cluster-name."""
+        return self._stored.cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, name: str):
+        """Set the cluster-name."""
+        self._stored.cluster_name = name
 
 
 if __name__ == "__main__":

--- a/charm-slurmdbd/src/interface_slurmdbd.py
+++ b/charm-slurmdbd/src/interface_slurmdbd.py
@@ -110,6 +110,8 @@ class Slurmdbd(Object):
         self._store_jwt_rsa(jwt_rsa)
         self.on.slurmctld_available.emit()
 
+        self._charm.cluster_name = event_app_data.get("cluster_name")
+
     def _on_relation_broken(self, event):
         """Clear the application relation data and emit the event."""
         self.set_slurmdbd_info_on_app_relation_data("")

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.7.4


### PR DESCRIPTION
Bump slurm-ops-manager from 0.7.3 to @enrich-logs

Enrich fluentbit logs with labels for:
- hostname
- cluster name
- partition name (only for Slurmd nodes)
- service (nhc/slurmd/slurmctld/slurmdbd)

Depends on: https://github.com/omnivector-solutions/slurm-ops-manager/pull/72

Tests pass locally

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
