### PR TITLE
Elastic search addon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- add support for ElasticSearch Slurm addon
 - pin Operator Framework to 1.2.0
 
 0.8.4 - 2021-12-10

--- a/charm-slurmctld/metadata.yaml
+++ b/charm-slurmctld/metadata.yaml
@@ -37,6 +37,8 @@ requires:
     interface: slurmrestd
   influxdb-api:
     interface: influxdb-api
+  elasticsearch:
+    interface: elasticsearch
   fluentbit:
     interface: fluentbit
 

--- a/charm-slurmctld/src/interface_elasticsearch.py
+++ b/charm-slurmctld/src/interface_elasticsearch.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Elasticserch interface."""
+import logging
+
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
+
+logger = logging.getLogger()
+
+
+class ElasticsearchAvailableEvent(EventBase):
+    """ElasticsearchAvailable event."""
+
+
+class ElasticsearchUnAvailableEvent(EventBase):
+    """ElasticsearchUnAvailable event."""
+
+
+class ElasticsearchEvents(ObjectEvents):
+    """ElasticsearchEvents."""
+    elasticsearch_available = EventSource(ElasticsearchAvailableEvent)
+    elasticsearch_unavailable = EventSource(ElasticsearchUnAvailableEvent)
+
+
+class Elasticsearch(Object):
+    """Elasticsearch interface."""
+
+    _stored = StoredState()
+    on = ElasticsearchEvents()
+
+    def __init__(self, charm, relation_name):
+        """Observe relation events."""
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        self._stored.set_default(elasticsearch_host=str(),
+                                 elasticsearch_port=str())
+
+        self.framework.observe(self._charm.on[self._relation_name].relation_changed,
+                               self._on_relation_changed)
+
+        self.framework.observe(self._charm.on[self._relation_name].relation_broken,
+                               self._on_relation_broken)
+
+    def _on_relation_changed(self, event):
+        """Get server address and store it."""
+        ingress = event.relation.data[event.unit]["ingress-address"]
+        self._stored.elasticsearch_host = ingress
+        # elastic charm can't change the port, so hardcode it here
+        self._stored.elasticsearch_port = "9200"
+        self.on.elasticsearch_available.emit()
+
+    def _on_relation_broken(self, event):
+        """Clear elasticsearch_ingress and emit elasticsearch_unavailable."""
+        self._stored.elasticsearch_ingress = ""
+        self.on.elasticsearch_unavailable.emit()
+
+    @property
+    def elasticsearch_ingress(self) -> str:
+        """Return elasticsearch_ingress."""
+        host = self._stored.elasticsearch_host
+        port = self._stored.elasticsearch_port
+        if host:
+            return f"http://{host}:{port}"
+        else:
+            return ""


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Add new relation to ElasticSearch, using the Slurm Elastic Search addon.
When relating to ES, slurmctld creates a new index `<cluster-name>` with a
type `jobcomp`. For example, by default it will be
`osd-cluster/jobcomp`.

**How was the code tested?**

`make tests` pass locally.

Docs: https://github.com/omnivector-solutions/osd-documentation/pull/58


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
