### PR TITLE
Bump slurm-ops-manager from 0.8.1 to nvidia-workaround

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- fix: do not install Nvidia repository by default
 - add support for custom NHC parameters
 - improve checks when nodes need to be rebooted
 - add Nvidia GPU support: install drivers via an action on compute nodes

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,5 @@
 ops==1.3.0
 influxdb
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,4 @@
 ops==1.3.0
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.1
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2

--- a/tests/40-nvidia.bats
+++ b/tests/40-nvidia.bats
@@ -22,5 +22,7 @@ load "../node_modules/bats-assert/load"
 
 @test "Querying the default repos" {
 	run juju run-action -m "$JUJU_MODEL" slurmd/leader nvidia-repo --wait
-	assert_output --regexp "developer.download.nvidia.com/compute/cuda/repos/(ubuntu2004|rhel7)"
+
+	# should not be set
+	assert_output --partial "nvidia-repo: \"\""
 }


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Workaround for nvidia repos infesting the base repos.

**How was the code tested?**

Tested only on Ubuntu due to the recent [Juju regression for CentOS](https://bugs.launchpad.net/juju/+bug/1964815)

To be merged after https://github.com/omnivector-solutions/slurm-ops-manager/pull/77


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
