### PR TITLE
Revert "metadata: remove series"

### DIFF
--- a/charm-slurmctld/metadata.yaml
+++ b/charm-slurmctld/metadata.yaml
@@ -20,6 +20,10 @@ tags:
     - slurm
     - hpc
 
+series:
+    - focal
+    - centos7
+
 peers:
   slurmctld-peer:
     interface: slurmctld-peer

--- a/charm-slurmd/metadata.yaml
+++ b/charm-slurmd/metadata.yaml
@@ -18,6 +18,10 @@ tags:
     - slurm
     - hpc
 
+series:
+    - focal
+    - centos7
+
 provides:
   slurmd:
     interface: slurmd

--- a/charm-slurmdbd/metadata.yaml
+++ b/charm-slurmdbd/metadata.yaml
@@ -17,6 +17,10 @@ tags:
   - slurm
   - hpc
 
+series:
+  - focal
+  - centos7
+
 provides:
   slurmdbd:
     interface: slurmdbd

--- a/charm-slurmrestd/metadata.yaml
+++ b/charm-slurmrestd/metadata.yaml
@@ -16,6 +16,10 @@ tags:
     - hpc
     - slurm
 
+series:
+    - focal
+    - centos7
+
 provides:
   slurmrestd:
     interface: slurmrestd


### PR DESCRIPTION
This reverts commit 2d90e785c9b65b1e2908aad81b825eede9f53633.

Juju is still not ready to remove the series metadata from the charms,
see https://github.com/juju/juju/pull/13847 for details


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [ ] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
