### PR TITLE
Inventory work

### DIFF
--- a/.github/workflows/publish-candidate.yaml
+++ b/.github/workflows/publish-candidate.yaml
@@ -65,7 +65,7 @@ jobs:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
           extension="_ubuntu-20.04-amd64_centos-7-amd64.charm"
-          release="--release=latest/edge --release=latest/candidate"
+          release="--release=edge --release=candidate"
 
           charmcraft upload "$release" slurmctld$extension --resource etcd:1
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- added set-node-inventory slurmd action
+- fix get-node-inventory action
+
 0.9.0 - 2022-04-12
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ In the case things aren't working as expected, please [file a bug](https://githu
 The slurm charms are maintained under the MIT license. See `LICENSE` file in
 this directory for full preamble.
 
-Copyright &copy; Omnivector Solutions 2021 
+Copyright &copy; Omnivector Solutions 2021 - 2022.

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,5 @@
 ops==1.3.0
 influxdb
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -4,6 +4,12 @@ node-configured:
   description: Remove a node from DownNodes when the reason is `New node`.
 get-node-inventory:
   description: Return node inventory.
+set-node-inventory:
+  description: Modify node inventory.
+  params:
+    real-memory:
+      type: integer
+      description: Total amount of memory of the node, in MB.
 
 show-nhc-config:
   description: Display the currently used `nhc.conf`.

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,4 @@
 ops==1.3.0
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -366,6 +366,7 @@ class SlurmdCharm(CharmBase):
     def _on_get_node_inventory_action(self, event):
         """Return node inventory."""
         inventory = self._slurmd.node_inventory
+        logger.debug(f'### Node inventory: {inventory}')
         event.set_results({'inventory': inventory})
 
     def get_infiniband_repo(self, event):

--- a/charm-slurmd/src/utils.py
+++ b/charm-slurmd/src/utils.py
@@ -5,6 +5,8 @@ import random
 import subprocess
 import sys
 
+from slurm_ops_manager.utils import get_real_mem
+
 
 def lscpu():
     """Return lscpu as a python dictionary."""
@@ -37,20 +39,6 @@ def cpu_info():
     }
 
 
-def free_m():
-    """Return the real memory."""
-    real_mem = ""
-    try:
-        real_mem = subprocess.check_output(
-            "free -m | grep -oP '\\d+' | head -n 1", shell=True
-        )
-    except subprocess.CalledProcessError as e:
-        print(e)
-        sys.exit(-1)
-
-    return real_mem.decode().strip()
-
-
 def lspci_nvidia():
     """Check for and return the count of nvidia gpus."""
     gpus = 0
@@ -81,7 +69,7 @@ def get_inventory(node_name, node_addr):
         "node_name": node_name,
         "node_addr": node_addr,
         "state": "UNKNOWN",
-        "real_memory": free_m(),
+        "real_memory": get_real_mem(),
         **cpu_info(),
     }
 

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
 git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.2
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3

--- a/run_tests
+++ b/run_tests
@@ -8,6 +8,8 @@ else
 	echo "Bats installed"
 fi
 
+. tests/utils.sh
+
 # create juju models for centos and ubuntu
 postfix=$(date +'%Y-%m-%d-')$RANDOM
 centos_model="centos-test-$postfix"
@@ -18,6 +20,7 @@ for model in $centos_model $ubuntu_model; do
 	juju add-model "$model"
 	juju switch "$model"
 	juju model-config --model "$model" logging-config="<unit>=DEBUG;<root>=DEBUG"
+	juju model-config --model "$model" update-status-hook-interval=1m
 	juju wait-for model "$model" --timeout=10s
 
 	cd ../slurm-bundles
@@ -32,6 +35,8 @@ for model in $centos_model $ubuntu_model; do
 	juju wait-for unit slurmdbd/0 --query='agent-status=="idle"' --timeout=9m
 	juju wait-for unit slurmrestd/0 --query='agent-status=="idle"' --timeout=9m
 	juju wait-for unit slurmd/0 --query='agent-status=="idle"' --timeout=9m
+
+	myjuju run --all --model "$model" "sudo reboot"
 
 	juju status
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,7 +22,7 @@ version_string="${version_date}\n$(echo $version_date | sed -e 's|.|-|g')\n"
 sed -i -e 9a"$version_string" CHANGELOG
 
 echo -e "Creating commit and tag:"
-changes="\n$(tail -n +13 CHANGELOG | sed -e "/-----/,999999d" | head -n -1)"
+changes="$(tail -n +13 CHANGELOG | sed -e "/-----/,999999d" | head -n -1)"
 echo -e "Release $new_version"
 echo -e "$changes"
 

--- a/tests/00-slurm-init.bats
+++ b/tests/00-slurm-init.bats
@@ -58,6 +58,9 @@ load "../node_modules/bats-assert/load"
 		fi
 	done
 
+	# reboot new node
+	myjuju run --model $JUJU_MODEL --unit slurmd/1 sudo reboot
+
 	# old node should still be idle
 	run juju run "sinfo -n $old_node" -m $JUJU_MODEL --unit slurmctld/leader
 	assert_success


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Add new action set-node-inventory that allows the operator to change the
RealMemory of a node. This patch does not allow other items of the
inventory to be modified, although we have everything in place to
implement it.

To be merged after https://github.com/omnivector-solutions/slurm-ops-manager/pull/78

**How was the code tested?**

local tests


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
