### PR TITLE
slurmctld: fix influxdb-info action

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Unreleased
 
 - added set-node-inventory slurmd action
 - fix get-node-inventory action
+- fix influxdb-info slurmctld action
 
 0.9.0 - 2022-04-12
 ------------------

--- a/charm-slurmctld/src/charm.py
+++ b/charm-slurmctld/src/charm.py
@@ -599,9 +599,13 @@ class SlurmctldCharm(CharmBase):
         influxdb_info = self._get_influxdb_info()
 
         if not influxdb_info:
-            influxdb_info = "not related"
+            info = "not related"
+        else:
+            # Juju does not like underscores in dictionaries
+            info = {k.replace("_", "-"): v for k, v in influxdb_info.items()}
+
         logger.debug(f"## InfluxDB-info action: {influxdb_info}")
-        event.set_results({"influxdb": influxdb_info})
+        event.set_results({"influxdb": info})
 
     def _on_create_user_group(self, event):
         """Create the user and group provided."""

--- a/tests/50-influxdb.bats
+++ b/tests/50-influxdb.bats
@@ -1,0 +1,41 @@
+#!/bin/npx bats
+
+load "../node_modules/bats-support/load"
+load "../node_modules/bats-assert/load"
+. "tests/utils.sh"
+
+
+@test "test influxdb-info action work without relation" {
+	run juju run-action --model $JUJU_MODEL slurmctld/leader influxdb-info --wait
+	assert_output --regexp "influxdb: not related"
+}
+
+@test "test we can deploy influxdb and relate it to slurmctld" {
+	run juju deploy --model $JUJU_MODEL influxdb
+
+	juju wait-for application influxdb --query='status=="active"' --timeout=9m > /dev/null 2>&1
+	myjuju relate slurmctld:influxdb-api influxdb:query
+
+	run juju status --model $JUJU_MODEL --relations
+	assert_output --regexp "slurmctld:influxdb-api"
+	assert_output --regexp "influxdb:query"
+}
+
+@test "test influxdb-info action work after the relation" {
+	run juju run-action --model $JUJU_MODEL slurmctld/leader influxdb-info --wait
+
+	assert_output --regexp "database: osd-cluster"
+	assert_output --regexp "ingress: [0-9]"
+	assert_output --regexp "password: [a-zA-Z0-9]*"
+	assert_output --regexp "port: \"8086\""
+	assert_output --regexp "retention-policy: autogen"
+	assert_output --regexp "user: slurm"
+}
+
+@test "test removing influxdb relation cleans up the relation data without breaking" {
+	myjuju remove-relation slurmctld:influxdb-api influxdb:query
+	juju wait-for unit slurmctld/0 --query='agent-status=="idle"'  --timeout=2m
+
+	run juju run-action --model $JUJU_MODEL slurmctld/leader influxdb-info --wait
+	assert_output --regexp "influxdb: not related"
+}


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Fix the `influxdb-info` slurmctld action. Running the function was crashing the code due to a change in how Juju/ops expects the output values.

New tests added:
- test the action
- test the relation to influxdb
- test removing the relation

Adds ~50 seconds to the total time to run all tests.

**How was the code tested?**

Local test suite pass.


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
