### PR TITLE
bump slurm-ops-manager from 0.8.3 to update-mlnx-drivers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Unreleased
 ----------
 
 - added set-node-inventory slurmd action
+- updated default Mellanox Infiniband drivers to version 5.4
 - fix get-node-inventory action
 - fix influxdb-info slurmctld action
 

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,4 @@
 ops==1.3.0
 influxdb
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
-git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,3 @@
 ops==1.3.0
 etcd3gw==1.0.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
-git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4

--- a/charm-slurmdbd/metadata.yaml
+++ b/charm-slurmdbd/metadata.yaml
@@ -24,9 +24,6 @@ series:
 provides:
   slurmdbd:
     interface: slurmdbd
-  nrpe-external-master:
-    interface: nrpe-external-master
-    scope: container
 
 requires:
   db:

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,3 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
-git+https://github.com/omnivector-solutions/interface-nrpe-external-master.git@master
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -7,7 +7,6 @@ from time import sleep
 from interface_mysql import MySQLClient
 from interface_slurmdbd import Slurmdbd
 from interface_slurmdbd_peer import SlurmdbdPeer
-# from nrpe_external_master import Nrpe
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, StoredState
 from ops.main import main
@@ -57,7 +56,6 @@ class SlurmdbdCharm(CharmBase):
         )
 
         self._db = MySQLClient(self, "db")
-        # self._nrpe = Nrpe(self, "nrpe-external-master")
         self._slurm_manager = SlurmManager(self, "slurmdbd")
         self._slurmdbd = Slurmdbd(self, "slurmdbd")
         self._slurmdbd_peer = SlurmdbdPeer(self, "slurmdbd-peer")

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.3
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

This version updates the OFED drivers from 5.3 to 5.4
Depends on https://github.com/omnivector-solutions/slurm-ops-manager/pull/79

**How was the code tested?**



Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
