### PR TITLE
slurmctl: add support for TLS certificates

### DIFF
--- a/.github/workflows/publish-candidate.yaml
+++ b/.github/workflows/publish-candidate.yaml
@@ -67,7 +67,7 @@ jobs:
           extension="_ubuntu-20.04-amd64_centos-7-amd64.charm"
           release="--release=edge --release=candidate"
 
-          charmcraft upload "$release" slurmctld$extension --resource etcd:1
+          charmcraft upload $release slurmctld$extension --resource etcd:1
 
           for charm in slurmd slurmdbd slurmrestd; do
               charmcraft upload "$release" "$charm$extension"

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,17 @@
 *.snap
 *.resource
 *.charm
+*.crt
+*.key
+*.srl
+*.csr
+*.v3.ext
 venv
 out
 build
 tmp
 node_modules/
+**__pycache__
 .env
 version
 charm-slurm*/version

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- added slurmctld configuration options to use TLS certificates for etcd
+
 0.9.1 - 2022-06-02
 ------------------
 

--- a/charm-slurmctld/config.yaml
+++ b/charm-slurmctld/config.yaml
@@ -91,3 +91,19 @@ options:
 
       This value supplements the charm supplied `acct_gather.conf` file that is
       used for configuring the acct_gather plugins.
+
+  tls-key:
+    type: string
+    default: ""
+    description: A TLS server private key (`.key` file) to be used.
+  tls-cert:
+    type: string
+    default: ""
+    description: A TLS server certificate (`.crt` file) to be used.
+  tls-ca-cert:
+    type: string
+    default: ""
+    description: |
+      A CA certificate (`.crt` file) to be used for verification of TLS
+      certificates. A CA certificate should only be issued in the case of
+      custom CAs and nodes not having it installed.

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,5 @@
 ops==1.3.0
 influxdb
 etcd3gw==1.0.2
+jinja2==3.1.2
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,5 @@
 ops==1.3.0
-influxdb
+influxdb==5.3.1
 etcd3gw==1.0.2
 jinja2==3.1.2
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4

--- a/charm-slurmctld/src/interface_slurmd.py
+++ b/charm-slurmctld/src/interface_slurmd.py
@@ -91,6 +91,9 @@ class Slurmd(Object):
 
         app_relation_data["etcd_slurmd_pass"] = self._charm.etcd_slurmd_password
 
+        app_relation_data["tls_cert"] = self._charm.model.config["tls-cert"]
+        app_relation_data["ca_cert"] = self._charm.model.config["tls-ca-cert"]
+
     def _on_relation_changed(self, event):
         """Emit slurmd available event."""
         if event.relation.data[event.app].get("partition_info"):
@@ -177,6 +180,22 @@ class Slurmd(Object):
             for relation in relations:
                 app = self.model.app
                 relation.data[app]["nhc_params"] = params
+        else:
+            logger.debug("## slurmd not joined")
+
+    def set_tls_settings(self):
+        """Send TLS settings to all slurmd."""
+        tls_cert = self._charm.model.config["tls-cert"]
+        ca_cert = self._charm.model.config["tls-ca-cert"]
+
+        logger.debug(f"## set_tls_settings: {bool(tls_cert)}, {bool(ca_cert)}")
+
+        if self.is_joined:
+            relations = self._charm.framework.model.relations.get(self._relation_name)
+            for relation in relations:
+                app = self.model.app
+                relation.data[app]["tls_cert"] = ca_cert
+                relation.data[app]["ca_cert"] = ca_cert
         else:
             logger.debug("## slurmd not joined")
 

--- a/charm-slurmctld/src/templates/etcd.env.tmpl
+++ b/charm-slurmctld/src/templates/etcd.env.tmpl
@@ -1,0 +1,9 @@
+ETCD_NAME=osd-etcd
+ETCD_DATA_DIR=/var/lib/etcd
+ETCD_LISTEN_CLIENT_URLS={{ protocol }}://0.0.0.0:2379
+ETCD_ADVERTISE_CLIENT_URLS={{ protocol }}://0.0.0.0:2379
+
+{% if use_tls %}
+ETCD_CERT_FILE={{ tls_cert_path }}
+ETCD_KEY_FILE={{ tls_key_path }}
+{% endif %}

--- a/charm-slurmctld/src/templates/etcd.service.tmpl
+++ b/charm-slurmctld/src/templates/etcd.service.tmpl
@@ -8,10 +8,7 @@ Wants=network-online.target local-fs.target remote-fs.target time-sync.target
 User=etcd
 Group=etcd
 Type=notify
-Environment=ETCD_DATA_DIR=/var/lib/etcd
-Environment=ETCD_NAME=osd-etcd
-Environment=ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
-Environment=ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+EnvironmentFile=-{{ environment_file }}
 ExecStart=/usr/bin/etcd
 Restart=always
 RestartSec=10s

--- a/charm-slurmd/src/interface_slurmd.py
+++ b/charm-slurmd/src/interface_slurmd.py
@@ -110,6 +110,7 @@ class Slurmd(Object):
         self._store_nhc_params(app_data.get("nhc_params"))
 
         self._charm.store_etcd_slurmd_pass(app_data.get("etcd_slurmd_pass"))
+        self._store_tls_params(app_data.get("tls_cert"), app_data.get("ca_cert"))
 
         self.on.slurmctld_available.emit()
 
@@ -118,10 +119,12 @@ class Slurmd(Object):
 
         Possible scenarios:
         - nhc parameters changed
+        - tls parameters changed
         """
 
         app_data = event.relation.data[event.app]
         self._store_nhc_params(app_data.get("nhc_params"))
+        self._store_tls_params(app_data.get("tls_cert"), app_data.get("ca_cert"))
 
     def _on_relation_broken(self, event):
         """Perform relation broken operations."""
@@ -185,6 +188,15 @@ class Slurmd(Object):
 
             logger.debug(f"## rendering /usr/sbin/omni-nhc-wrapper: {params}")
             self._charm._slurm_manager.render_nhc_wrapper(params)
+
+    def _store_tls_params(self, tls_cert: str, ca_cert: str = ""):
+        """Store TLS certificates in the charm storedState."""
+        logger.debug(f"## storing new tls params: {bool(tls_cert)}, {bool(ca_cert)}")
+        if tls_cert != self._charm.etcd_tls_cert:
+            self._charm.etcd_tls_cert = tls_cert
+
+        if ca_cert != self._charm.etcd_ca_cert:
+            self._charm.etcd_ca_cert = ca_cert
 
     @property
     def slurmctld_address(self) -> str:

--- a/tests/70-tls.bats
+++ b/tests/70-tls.bats
@@ -1,0 +1,85 @@
+#!/bin/npx bats
+
+load "../node_modules/bats-support/load"
+load "../node_modules/bats-assert/load"
+. "tests/utils.sh"
+
+# etcd host and port
+host=$(juju run --unit slurmctld/leader "unit-get public-address")
+port=2379
+
+CANAME=Omni-RootCA
+MYCERT=etcd
+
+
+# generate certs
+function create_certs()
+{
+	# create the CA
+	openssl genrsa -aes256 -passout pass:1234 -out $CANAME.key 4096
+	openssl req -x509 -new -nodes -passin pass:1234 -key $CANAME.key \
+	            -sha256 -days 1826 -out $CANAME.crt \
+	            -subj '/CN=Omni-RootCA/OU=Omni'
+
+	# create the server certs
+	openssl req -new -nodes -out $MYCERT.csr -newkey rsa:4096 \
+	            -keyout $MYCERT.key -subj '/O=Omnietcd/CN=HPC'
+
+	local slurmctld_hostname=$(juju run --unit slurmctld/leader "hostname")
+	cat > $MYCERT.v3.ext << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = $slurmctld_hostname
+IP.1 = 127.0.0.1
+IP.2 = $host
+EOF
+
+	openssl x509 -req -passin pass:1234 -in $MYCERT.csr -CA $CANAME.crt \
+	             -CAkey $CANAME.key -CAcreateserial -out $MYCERT.crt \
+	             -days 730 -sha256 -extfile $MYCERT.v3.ext
+}
+
+
+@test "Assert we can setup TLS" {
+	create_certs
+
+	juju config --model "$JUJU_MODEL" slurmctld tls-cert="$(cat etcd.crt)"
+	juju config --model "$JUJU_MODEL" slurmctld tls-key="$(cat etcd.key)"
+	juju config --model "$JUJU_MODEL" slurmctld tls-ca-cert="$(cat Omni-RootCA.crt)"
+
+	sleep 5
+	juju wait-for unit slurmctld/0 --query='agent-status=="idle"' --timeout=9m
+
+	# etcd should still be up
+	run curl -s -X POST "https://$host:$port/v3/maintenance/status" --cacert etcd.crt
+	assert_output --regexp '"version":"3.5.0"'
+}
+
+@test "Assert we can get the nodelist with TLS cert" {
+	local password=$(juju run-action slurmctld/leader etcd-get-slurmd-password --wait --format=json | jq .[].results.password)
+	local key=$(printf nodes/all_nodes | base64)
+
+	local url="https://$host:$port/v3/auth/authenticate"
+	local token=$(curl -L -s -X POST "$url" -d '{"name":"slurmd", "password":"'"${password//\"/}"'"}' --cacert etcd.crt | jq .token)
+
+	run curl -X POST "https://$host:$port/v3/kv/range" -d '{"key":"'$key'"}' -H "Authorization: ${token//\"/}" --cacert etcd.crt
+	assert_output --regexp "\"key\":\"$key"
+}
+
+
+@test "Assert we can remove TLS certs" {
+	juju config --model "$JUJU_MODEL" slurmctld tls-cert=""
+	juju config --model "$JUJU_MODEL" slurmctld tls-key=""
+	juju config --model "$JUJU_MODEL" slurmctld tls-ca-cert=""
+
+	sleep 5
+	juju wait-for unit slurmctld/0 --query='agent-status=="idle"' --timeout=9m
+
+	# etcd should still be up
+	run curl -X POST "http://$host:$port/v3/maintenance/status"
+	assert_output --regexp '"version":"3.5.0"'
+}


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Add three configurations in slurmctld charm to allow the operator to
supply TLS certificates for etcd.

Documentation in: https://github.com/omnivector-solutions/osd-documentation/pull/72

**How was the code tested?**

New tests for TLS certs added.



Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
