### PR TITLE
Handle etcd configurations after updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Unreleased
 - updated default Mellanox Infiniband drivers to version 5.4
 - fix get-node-inventory action
 - fix influxdb-info slurmctld action
+- fix etcd not being configured after an upgrade
 
 0.9.0 - 2022-04-12
 ------------------


### PR DESCRIPTION

**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

After upgrading the slurmctld-charm, we need to configure roles and
usernames if this had not hapenned, e.g. when upgrading from versions
older than 0.9.0.

**How was the code tested?**




Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
