### PR TITLE
Add singularity installation in slurmd via .deb and .rpm

### DIFF
--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -2,4 +2,4 @@ ops==1.3.0
 influxdb==5.3.1
 etcd3gw==1.0.2
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4
+git+https://github.com/jaimesouza/slurm-ops-manager.git@jaime-dev-singularity

--- a/charm-slurmd/metadata.yaml
+++ b/charm-slurmd/metadata.yaml
@@ -33,3 +33,16 @@ requires:
 peers:
   slurmd-peer:
     interface: slurmd-peer
+
+resources:
+  singularity-deb:
+    type: file
+    filename: singularity-ce_3.10.2-focal_amd64.deb
+    description: >
+      Singularity .deb file.
+  
+  singularity-rpm:
+    type: file
+    filename: singularity-ce-3.10.2-1.el7.x86_64.rpm
+    description: >
+      Singularity .rpm file.

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
 etcd3gw==1.0.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4
+git+https://github.com/jaimesouza/slurm-ops-manager.git@jaime-dev-singularity

--- a/charm-slurmd/src/singularity_ops.py
+++ b/charm-slurmd/src/singularity_ops.py
@@ -1,0 +1,42 @@
+import logging
+import subprocess
+from pathlib import Path
+from slurm_ops_manager.utils import operating_system
+
+logger = logging.getLogger()
+
+
+class SingularityOps:
+    """Singularity ops."""
+
+    def __init__(self, charm):
+        """Initialize class."""
+        self._charm = charm
+
+    def install(self, resource_path: Path):
+        """Install singularity."""
+
+        logger.debug(f"## Installing singularity from: {resource_path}")
+
+        try:
+            if operating_system() == 'ubuntu':
+                self._install_deb(resource_path)
+            else:
+                self._install_rpm(resource_path)
+
+            logger.debug("## Singularity successfully installed")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"## Error installing singularity - {e}")
+
+    def _install_deb(self, resource_path: Path):
+        """Install on ubuntu using .deb"""
+
+        cmd = f"apt install {resource_path} -y".split()
+        subprocess.check_output(cmd)
+
+    def _install_rpm(self, resource_path: Path):
+        """Install on centos using .rpm"""
+
+        cmd = f"yum localinstall {resource_path} -y".split()
+        subprocess.check_output(cmd)

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4
+git+https://github.com/jaimesouza/slurm-ops-manager.git@jaime-dev-singularity

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.4
+git+https://github.com/jaimesouza/slurm-ops-manager.git@jaime-dev-singularity

--- a/tests/80-singularity.bats
+++ b/tests/80-singularity.bats
@@ -1,0 +1,14 @@
+#!/bin/npx bats
+
+load "../node_modules/bats-support/load"
+load "../node_modules/bats-assert/load"
+. "tests/utils.sh"
+
+
+@test "test singularity is installed" {
+	partition="Unit-test-partition"
+	myjuju config --model $JUJU_MODEL slurmd partition-name="$partition"
+
+	run juju run --unit slurmd/0 --model "$JUJU_MODEL" "singularity --version"
+	assert_output --partial "singularity-ce version "
+}


### PR DESCRIPTION
This new feature adds the singularity installation in the slurmd setup process. 

The installation can be done with .deb (Ubuntu) or .rpm (Centos7)

This PR requires an updated branch of slurm-ops-manager:

https://github.com/jaimesouza/slurm-ops-manager/tree/jaime-dev-singularity

And also an updated branch of slurm-bundles:

https://github.com/jaimesouza/slurm-bundles/tree/jaime-dev-singularity

**How was the code tested?**

The code was tested with the following commands:

`juju deploy ./slurmd.charm dev--resource singularity-deb=../slurm-bundles/singularity-ce_3.10.2-focal_amd64.deb`

`juju deploy ./slurmd.charm dev --resource singularity-rpm=../slurm-bundles/singularity-ce-3.10.2-1.el7.x86_64.rpm --series centos7`

A simple test can be found in `tests/80-singularity.bats`.


Final checklist
- [ x ] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [ x ] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
