### PR TITLE
Fix a misspelled word in singularity-install action description

### DIFF
--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -96,4 +96,4 @@ singularity-install:
     This action will install singularity using the official .deb (Ubuntu) 
     or .rpm (CentOS) packages retrieved from GitHub Releases.
 
-    Note: The .deb or .rpm files must be suppliead as Juju resources.
+    Note: The .deb or .rpm files must be supplied as Juju resources.


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

It is just a small fix.

Change `suppliead ` for `supplied ` in https://github.com/omnivector-solutions/slurm-charms/blob/master/charm-slurmd/actions.yaml#L99

**How was the code tested?**

No test needed.


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
