### PR TITLE
Add action to install MPI (mpich) on slurmd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- added action in slurmd to install MPI (mpich)
+
 0.10.0 - 2022-09-15
 -------------------
 

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -2,4 +2,4 @@ ops==1.3.0
 influxdb==5.3.1
 etcd3gw==1.0.2
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -2,4 +2,4 @@ ops==1.3.0
 influxdb==5.3.1
 etcd3gw==1.0.2
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.7

--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -100,7 +100,4 @@ singularity-install:
 
 mpi-install:
   description: >
-    Install MPI (mpich). This might take a few minutes to complete.
-
-    This action will install mpich using the package manager 
-    apt-get (Ubuntu) or yum (CentOS).
+    Install MPI (`mpich`). This might take a few minutes to complete.

--- a/charm-slurmd/actions.yaml
+++ b/charm-slurmd/actions.yaml
@@ -97,3 +97,10 @@ singularity-install:
     or .rpm (CentOS) packages retrieved from GitHub Releases.
 
     Note: The .deb or .rpm files must be supplied as Juju resources.
+
+mpi-install:
+  description: >
+    Install MPI (mpich). This might take a few minutes to complete.
+
+    This action will install mpich using the package manager 
+    apt-get (Ubuntu) or yum (CentOS).

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
 etcd3gw==1.0.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
 etcd3gw==1.0.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.7

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -101,6 +101,8 @@ class SlurmdCharm(CharmBase):
             self.on.nvidia_install_action: self.nvidia_install,
             # singularity actions
             self.on.singularity_install_action: self.singularity_install,
+            # mpi actions
+            self.on.mpi_install_action: self.mpi_install,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -528,6 +530,11 @@ class SlurmdCharm(CharmBase):
             except ModelError as e:
                 logger.error(f"## Missing singularity resource - {e}")
                 event.fail(message=f'Error installing Singularity: {e.output}')
+
+    def mpi_install(self, event):
+        """Install MPI (mpich)."""
+        self._slurm_manager.mpi.install()
+        event.set_results({'installation': 'Successfull.'})
 
     def _on_show_nhc_config(self, event):
         """Show current nhc.conf."""

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -534,7 +534,9 @@ class SlurmdCharm(CharmBase):
     def mpi_install(self, event):
         """Install MPI (mpich)."""
         self._slurm_manager.mpi.install()
-        event.set_results({'installation': 'Successfull.'})
+
+        if self._slurm_manager.mpi.installed():
+            event.set_results({'installation': 'Successfull.'})
 
     def _on_show_nhc_config(self, event):
         """Show current nhc.conf."""

--- a/charm-slurmd/src/charm.py
+++ b/charm-slurmd/src/charm.py
@@ -537,6 +537,8 @@ class SlurmdCharm(CharmBase):
 
         if self._slurm_manager.mpi.installed():
             event.set_results({'installation': 'Successfull.'})
+        else:
+            event.fail(message='Error installing mpich. Check the logs.')
 
     def _on_show_nhc_config(self, event):
         """Show current nhc.conf."""

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.7

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.6
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@mpi_install
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.7

--- a/tests/90-mpi.bats
+++ b/tests/90-mpi.bats
@@ -7,6 +7,6 @@ load "../node_modules/bats-assert/load"
 
 @test "test MPI is installed" {
 	run juju run-action -m "$JUJU_MODEL" slurmd/leader mpi-install --wait
-	run juju run --unit slurmd/leader --model "$JUJU_MODEL" "mpirun --version"
+	run juju run --unit slurmd/leader --model "$JUJU_MODEL" "PATH=/usr/lib64/mpich-3.2/bin:$PATH && mpirun --version"
 	assert_output --partial "HYDRA build "
 }

--- a/tests/90-mpi.bats
+++ b/tests/90-mpi.bats
@@ -1,0 +1,12 @@
+#!/bin/npx bats
+
+load "../node_modules/bats-support/load"
+load "../node_modules/bats-assert/load"
+. "tests/utils.sh"
+
+
+@test "test MPI is installed" {
+	run juju run-action -m "$JUJU_MODEL" slurmd/leader mpi-install --wait
+	run juju run --unit slurmd/leader --model "$JUJU_MODEL" "mpirun --version"
+	assert_output --partial "HYDRA build "
+}


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Add an action on charm-slurmd to install MPI (mpich) using the package manager.

**How was the code tested?**

`juju run-action slurmd/leader mpi-install`

A simple test (90-mpi.bats) was implemented to verify if the mpich is installed.
It was tested with Ubuntu and Centos7 systems.

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
