### PR TITLE
Add dependency between CI/CD workflows

### DIFF
--- a/.github/workflows/publish-candidate.yaml
+++ b/.github/workflows/publish-candidate.yaml
@@ -6,9 +6,12 @@ on:
       - "*"
 
 jobs:
+  run-tests:
+    uses: ./.github/workflows/run-tests.yaml
   build-charms:
     name: "Build the charms"
     runs-on: "ubuntu-20.04"
+    needs: [run-tests]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -5,9 +5,12 @@ on:
     types: [closed]
 
 jobs:
+  run-tests:
+    uses: ./.github/workflows/run-tests.yaml
   build-charms:
     name: "Build the charms"
     runs-on: "ubuntu-20.04"
+    needs: [run-tests]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,8 @@ name: Integration Tests
 on:
   push:
     branches: [ "master" ]
-  pull_request:
+  pull_request:  
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
**Please provide a description of the purpose of this pull request, as well as its
motivation and context.**

The `publish-candidate` and `publish-edge` workflows should run the tests before publishing the charms.

This is important to make sure nothing broken is published.

This PR adds a dependency in the `publish-candidate` and `publish-edge` workflows to run after and only if the `run-tests` workflow runs successfully.

**How was the code tested?**

Please describe the conditions under which the code has been tested.


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
