### PR TITLE
support mysql-router and mysql-innodb-cluster

### DIFF
--- a/charm-slurmdbd/metadata.yaml
+++ b/charm-slurmdbd/metadata.yaml
@@ -26,8 +26,8 @@ provides:
     interface: slurmdbd
 
 requires:
-  db:
-    interface: mysql
+  shared-db:
+    interface: mysql-shared
   fluentbit:
     interface: fluentbit
 

--- a/charm-slurmdbd/src/charm.py
+++ b/charm-slurmdbd/src/charm.py
@@ -55,7 +55,7 @@ class SlurmdbdCharm(CharmBase):
             cluster_name=str()
         )
 
-        self._db = MySQLClient(self, "db")
+        self._db = MySQLClient(self, "shared-db")
         self._slurm_manager = SlurmManager(self, "slurmdbd")
         self._slurmdbd = Slurmdbd(self, "slurmdbd")
         self._slurmdbd_peer = SlurmdbdPeer(self, "slurmdbd-peer")


### PR DESCRIPTION
Change the interface name to match the new mysql-router interface.

Accompanies the [slurm-bundles pr](https://github.com/omnivector-solutions/slurm-bundles/pull/31)

In order to use the new MySQL innodb cluster and router charms, we need to have a matching interface on slurmdbd.

This code is not ready for merge. This PR is merely a draft.

Currently hitting issues here.

```bash

Model  Controller           Cloud/Region         Version  SLA          Timestamp
rats   localhost-localhost  localhost/localhost  2.9.35   unsupported  19:55:48Z

App            Version          Status   Scale  Charm                 Channel     Rev  Exposed  Message
mysql-cluster  8.0.31           active       3  mysql-innodb-cluster  8.0/stable   30  no       Unit is ready: Mode: R/W, Cluster is ONLINE and can tolerate up to ONE failure.
mysql-router   8.0.31           waiting      1  mysql-router          8.0/stable   35  no       'shared-db' incomplete, Waiting for proxied DB creation from cluster
slurmctld      1.0.0-3-ge57...  blocked      1  slurmctld                           0  no       Machine needs reboot
slurmd         1.0.0-3-ge57...  blocked      1  slurmd                              0  no       Machine needs reboot
slurmdbd       1.0.0-3-ge57...  blocked      1  slurmdbd                            0  no       Machine needs reboot
slurmrestd     1.0.0-3-ge57...  blocked      1  slurmrestd                          0  no       Machine needs reboot

Unit               Workload  Agent  Machine  Public address  Ports  Message
mysql-cluster/0*   active    idle   0        10.158.215.211         Unit is ready: Mode: R/W, Cluster is ONLINE and can tolerate up to ONE failure.
mysql-cluster/1    active    idle   1        10.158.215.234         Unit is ready: Mode: R/O, Cluster is ONLINE and can tolerate up to ONE failure.
mysql-cluster/2    active    idle   2        10.158.215.136         Unit is ready: Mode: R/O, Cluster is ONLINE and can tolerate up to ONE failure.
slurmctld/0*       blocked   idle   3        10.158.215.219         Machine needs reboot
slurmd/0*          blocked   idle   4        10.158.215.31          Machine needs reboot
slurmdbd/0*        blocked   idle   5        10.158.215.165         Machine needs reboot
  mysql-router/0*  waiting   idle            10.158.215.165         'shared-db' incomplete, Waiting for proxied DB creation from cluster
slurmrestd/0*      blocked   idle   6        10.158.215.28          Machine needs reboot

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.158.215.211  juju-92f6cb-0  jammy       Running
1        started  10.158.215.234  juju-92f6cb-1  jammy       Running
2        started  10.158.215.136  juju-92f6cb-2  jammy       Running
3        started  10.158.215.219  juju-92f6cb-3  focal       Running
4        started  10.158.215.31   juju-92f6cb-4  focal       Running
5        started  10.158.215.165  juju-92f6cb-5  focal       Running
6        started  10.158.215.28   juju-92f6cb-6  focal       Running

```