### PR TITLE
ASP-2712: Update requirements.txt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- set setuptools to be lower than 55
+- set Slurm 23.02.1 as default on slurm-ops-manager 0.8.13
+- set urllib3 as a requirement for slurmd and slurmctld and fix the version to 1.26.9
 - changed license to Apache-2.0
 - removed the action in slurmd to install InfiniBand drivers
 - removed the action in slurmd to install Nvidia drivers

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,5 +1,6 @@
 ops==1.3.0
 influxdb==5.3.1
+urllib3==1.26.9
 etcd3gw==1.0.2
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.13

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,3 +1,4 @@
 ops==1.3.0
+urllib3==1.26.9
 etcd3gw==1.0.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.13

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.13

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.13


### PR DESCRIPTION
Add urllib3==1.26.9 in the `slurmd` and `slurmctld` requirements. This is needed to avoid installing a newer version of urllib3, which can not run properly with Python 3.6.

Update `slurm-ops-manager ` to version `0.8.13`, which uses Slurm 23.02.1 as default on CentOS7.

**How was the code tested?**

The code has been tested locally


Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [x] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
