### PR TITLE
feat: Add a custom Python 3.8 installation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Slurm Charms.
 Unreleased
 ----------
 
+- added a custom python installation to run the charm code
+
 1.1.2 - 2023-09-07
 ------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Unreleased
 ----------
 
 - added a custom python installation to run the charm code
+- removed CentOS 8 support
 
 1.1.2 - 2023-09-07
 ------------------

--- a/charm-slurmctld/charmcraft.yaml
+++ b/charm-slurmctld/charmcraft.yaml
@@ -13,9 +13,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
-      - name: centos
-        channel: "8"
-        architectures: [amd64]
 parts:
   charm:
     build-packages: [git]

--- a/charm-slurmctld/dispatch
+++ b/charm-slurmctld/dispatch
@@ -1,49 +1,55 @@
 #!/bin/bash
-# This hook installs the centos dependencies needed to run the charm,
+# This hook installs the dependencies needed to run the charm,
 # creates the dispatch executable, regenerates the symlinks for start and
 # upgrade-charm, and kicks off the operator framework.
 
 set -e
 
-# Source the os-release information into the env.
+# Source the os-release information into the env
 . /etc/os-release
 
 if ! [[ -f '.installed' ]]
 then
-	# Determine if we are running in centos or ubuntu, if centos
-	# provision the needed prereqs.
-	if [[ $ID == 'ubuntu' ]]
-	then
-		echo "Running Ubuntu."
-		echo "Nothing to do."
-	elif [[ $ID == 'centos' ]]
-	then
-		# Determine the centos version and install prereqs accordingly
-		major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-			echo "Running CentOS$major, installing prereqs."
-		if [[ $major == "7" ]]
-		then
-			yum -y install epel-release
-			yum -y install yum-priorities python3
-		elif [[ $major == "8" ]]
-		then
-			dnf -y install epel-release
-			dnf -y install yum-priorities python3
-		else
-			echo "Running unsuppored version of centos: $major"
-			exit -1
-		fi
-	elif [[ $ID == 'rocky' ]]
+
+	# Rocky specific setup
+	if [[ $ID == 'rocky' ]]
 	then
 		dnf install epel-release -y
 		dnf install dnf-plugins-core -y
 		dnf config-manager --set-enabled powertools -y
-		dnf install make automake yum-utils -y
-	else
-		echo "Running unsuppored os: $ID"
-		exit -1
-	fi	
+	fi
+
+	if [[ $ID == 'centos' || $ID == 'rocky' ]]
+	then
+		# Install dependencies
+		yum -y install epel-release
+		yum -y install yum-priorities python3 automake yum-utils
+
+		# Install dependencies and build custom python		
+		yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel
+
+		export PYTHON_VERSION=3.8.16
+		wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
+		tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp
+		cd /tmp/Python-${PYTHON_VERSION}		
+		./configure --prefix=/opt/python/python3.8 --enable-optimizations
+		make -C /tmp/Python-${PYTHON_VERSION} -j $(nproc) altinstall
+		cd $OLDPWD
+		rm -rf /tmp/Python*
+
+		# set the correct python bin path
+		PYTHON_BIN="/opt/python/python3.8/bin/python3.8"
+	elif [[ $ID == 'ubuntu' ]]
+	then
+		# Necessary to compile and install NHC
+		apt-get install --assume-yes make
+
+		# set the correct python bin path
+		PYTHON_BIN="/usr/bin/env python3"
+	fi
+	
 	touch .installed
 fi
 
-JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py
+
+JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv $PYTHON_BIN ./src/charm.py

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,4 +1,4 @@
-ops==2.*
+ops==1.3.0
 influxdb==5.3.1
 urllib3==1.26.9
 etcd3gw==1.0.2

--- a/charm-slurmctld/requirements.txt
+++ b/charm-slurmctld/requirements.txt
@@ -1,6 +1,6 @@
-ops==1.3.0
+ops==2.*
 influxdb==5.3.1
 urllib3==1.26.9
 etcd3gw==1.0.2
 jinja2==3.1.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.15
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16

--- a/charm-slurmd/charmcraft.yaml
+++ b/charm-slurmd/charmcraft.yaml
@@ -13,9 +13,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
-      - name: centos
-        channel: "8"
-        architectures: [amd64]
 parts:
   charm:
     build-packages: [git]

--- a/charm-slurmd/dispatch
+++ b/charm-slurmd/dispatch
@@ -1,50 +1,55 @@
 #!/bin/bash
-# This hook installs the centos dependencies needed to run the charm,
+# This hook installs the dependencies needed to run the charm,
 # creates the dispatch executable, regenerates the symlinks for start and
 # upgrade-charm, and kicks off the operator framework.
 
 set -e
 
-# Source the os-release information into the env.
+# Source the os-release information into the env
 . /etc/os-release
 
 if ! [[ -f '.installed' ]]
 then
-	# Determine if we are running in centos or ubuntu, if centos
-	# provision the needed prereqs.
-	if [[ $ID == 'ubuntu' ]]
-	then
-		echo "Running Ubuntu."
-		# necessary to compile and install NHC
-		apt-get install --assume-yes make automake
-	elif [[ $ID == 'centos' ]]
-	then
-		# Determine the centos version and install prereqs accordingly
-		major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-			echo "Running CentOS$major, installing prereqs."
-		if [[ $major == "7" ]]
-		then
-			yum -y install epel-release
-			yum -y install yum-priorities python3 make automake yum-utils
-		elif [[ $major == "8" ]]
-		then
-			dnf -y install epel-release
-			dnf -y install yum-priorities python3 make automake yum-utils
-		else
-			echo "Running unsuppored version of centos: $major"
-			exit -1
-		fi
-	elif [[ $ID == 'rocky' ]]
+
+	# Rocky specific setup
+	if [[ $ID == 'rocky' ]]
 	then
 		dnf install epel-release -y
 		dnf install dnf-plugins-core -y
 		dnf config-manager --set-enabled powertools -y
-		dnf install make automake yum-utils -y
-	else
-		echo "Running unsuppored os: $ID"
-		exit -1
 	fi
+
+	if [[ $ID == 'centos' || $ID == 'rocky' ]]
+	then
+		# Install dependencies
+		yum -y install epel-release
+		yum -y install yum-priorities python3 automake yum-utils
+
+		# Install dependencies and build custom python		
+		yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel
+
+		export PYTHON_VERSION=3.8.16
+		wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
+		tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp
+		cd /tmp/Python-${PYTHON_VERSION}		
+		./configure --prefix=/opt/python/python3.8 --enable-optimizations
+		make -C /tmp/Python-${PYTHON_VERSION} -j $(nproc) altinstall
+		cd $OLDPWD
+		rm -rf /tmp/Python*
+
+		# set the correct python bin path
+		PYTHON_BIN="/opt/python/python3.8/bin/python3.8"
+	elif [[ $ID == 'ubuntu' ]]
+	then
+		# Necessary to compile and install NHC
+		apt-get install --assume-yes make
+
+		# set the correct python bin path
+		PYTHON_BIN="/usr/bin/env python3"
+	fi
+	
 	touch .installed
 fi
 
-JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py
+
+JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv $PYTHON_BIN ./src/charm.py

--- a/charm-slurmd/requirements.txt
+++ b/charm-slurmd/requirements.txt
@@ -1,4 +1,4 @@
 ops==1.3.0
 urllib3==1.26.9
 etcd3gw==1.0.2
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.15
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16

--- a/charm-slurmdbd/charmcraft.yaml
+++ b/charm-slurmdbd/charmcraft.yaml
@@ -13,9 +13,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
-      - name: centos
-        channel: "8"
-        architectures: [amd64]
 parts:
   charm:
     build-packages: [git]

--- a/charm-slurmdbd/dispatch
+++ b/charm-slurmdbd/dispatch
@@ -1,49 +1,55 @@
 #!/bin/bash
-# This hook installs the centos dependencies needed to run the charm,
+# This hook installs the dependencies needed to run the charm,
 # creates the dispatch executable, regenerates the symlinks for start and
 # upgrade-charm, and kicks off the operator framework.
 
 set -e
 
-# Source the os-release information into the env.
+# Source the os-release information into the env
 . /etc/os-release
 
 if ! [[ -f '.installed' ]]
 then
-	# Determine if we are running in centos or ubuntu, if centos
-	# provision the needed prereqs.
-	if [[ $ID == 'ubuntu' ]]
-	then
-		echo "Running Ubuntu."
-		echo "Nothing to do."
-	elif [[ $ID == 'centos' ]]
-	then
-		# Determine the centos version and install prereqs accordingly
-		major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-			echo "Running CentOS$major, installing prereqs."
-		if [[ $major == "7" ]]
-		then
-			yum -y install epel-release
-			yum -y install yum-priorities python3
-		elif [[ $major == "8" ]]
-		then
-			dnf -y install epel-release
-			dnf -y install yum-priorities python3
-		else
-			echo "Running unsuppored version of centos: $major"
-			exit -1
-		fi
-	elif [[ $ID == 'rocky' ]]
+
+	# Rocky specific setup
+	if [[ $ID == 'rocky' ]]
 	then
 		dnf install epel-release -y
 		dnf install dnf-plugins-core -y
 		dnf config-manager --set-enabled powertools -y
-		dnf install make automake yum-utils -y
-	else
-		echo "Running unsuppored os: $ID"
-		exit -1
 	fi
+
+	if [[ $ID == 'centos' || $ID == 'rocky' ]]
+	then
+		# Install dependencies
+		yum -y install epel-release
+		yum -y install yum-priorities python3 automake yum-utils
+
+		# Install dependencies and build custom python		
+		yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel
+
+		export PYTHON_VERSION=3.8.16
+		wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
+		tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp
+		cd /tmp/Python-${PYTHON_VERSION}		
+		./configure --prefix=/opt/python/python3.8 --enable-optimizations
+		make -C /tmp/Python-${PYTHON_VERSION} -j $(nproc) altinstall
+		cd $OLDPWD
+		rm -rf /tmp/Python*
+
+		# set the correct python bin path
+		PYTHON_BIN="/opt/python/python3.8/bin/python3.8"
+	elif [[ $ID == 'ubuntu' ]]
+	then
+		# Necessary to compile and install NHC
+		apt-get install --assume-yes make
+
+		# set the correct python bin path
+		PYTHON_BIN="/usr/bin/env python3"
+	fi
+	
 	touch .installed
 fi
 
-JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py
+
+JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv $PYTHON_BIN ./src/charm.py

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
-ops==2.*
+ops==1.3.0
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16

--- a/charm-slurmdbd/requirements.txt
+++ b/charm-slurmdbd/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.15
+ops==2.*
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16

--- a/charm-slurmrestd/charmcraft.yaml
+++ b/charm-slurmrestd/charmcraft.yaml
@@ -13,9 +13,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
-      - name: centos
-        channel: "8"
-        architectures: [amd64]
 parts:
   charm:
     build-packages: [git]

--- a/charm-slurmrestd/dispatch
+++ b/charm-slurmrestd/dispatch
@@ -1,49 +1,55 @@
 #!/bin/bash
-# This hook installs the centos dependencies needed to run the charm,
+# This hook installs the dependencies needed to run the charm,
 # creates the dispatch executable, regenerates the symlinks for start and
 # upgrade-charm, and kicks off the operator framework.
 
 set -e
 
-# Source the os-release information into the env.
+# Source the os-release information into the env
 . /etc/os-release
 
 if ! [[ -f '.installed' ]]
 then
-	# Determine if we are running in centos or ubuntu, if centos
-	# provision the needed prereqs.
-	if [[ $ID == 'ubuntu' ]]
-	then
-		echo "Running Ubuntu."
-		echo "Nothing to do."
-	elif [[ $ID == 'centos' ]]
-	then
-		# Determine the centos version and install prereqs accordingly
-		major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-			echo "Running CentOS$major, installing prereqs."
-		if [[ $major == "7" ]]
-		then
-			yum -y install epel-release
-			yum -y install yum-priorities python3
-		elif [[ $major == "8" ]]
-		then
-			dnf -y install epel-release
-			dnf -y install yum-priorities python3
-		else
-			echo "Running unsuppored version of centos: $major"
-			exit -1
-		fi
-	elif [[ $ID == 'rocky' ]]
+
+	# Rocky specific setup
+	if [[ $ID == 'rocky' ]]
 	then
 		dnf install epel-release -y
 		dnf install dnf-plugins-core -y
 		dnf config-manager --set-enabled powertools -y
-		dnf install make automake yum-utils -y
-	else
-		echo "Running unsuppored os: $ID"
-		exit -1
 	fi
+
+	if [[ $ID == 'centos' || $ID == 'rocky' ]]
+	then
+		# Install dependencies
+		yum -y install epel-release
+		yum -y install yum-priorities python3 automake yum-utils
+
+		# Install dependencies and build custom python		
+		yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel
+
+		export PYTHON_VERSION=3.8.16
+		wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
+		tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp
+		cd /tmp/Python-${PYTHON_VERSION}		
+		./configure --prefix=/opt/python/python3.8 --enable-optimizations
+		make -C /tmp/Python-${PYTHON_VERSION} -j $(nproc) altinstall
+		cd $OLDPWD
+		rm -rf /tmp/Python*
+
+		# set the correct python bin path
+		PYTHON_BIN="/opt/python/python3.8/bin/python3.8"
+	elif [[ $ID == 'ubuntu' ]]
+	then
+		# Necessary to compile and install NHC
+		apt-get install --assume-yes make
+
+		# set the correct python bin path
+		PYTHON_BIN="/usr/bin/env python3"
+	fi
+	
 	touch .installed
 fi
 
-JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py
+
+JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv $PYTHON_BIN ./src/charm.py

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
-ops==2.*
+ops==1.3.0
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16

--- a/charm-slurmrestd/requirements.txt
+++ b/charm-slurmrestd/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.15
+ops==2.*
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.16


### PR DESCRIPTION
- Update the dispatch file to install and use Python 3.8 to run the charm code instead of using the system Python 3.6.
- Remove CentOS 8 support, because it's not supported by Juju anymore.
- Update the `slurm-ops-manager` version.

